### PR TITLE
fix empty String/CharArray decoding

### DIFF
--- a/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -38,7 +38,7 @@ fun CharArray.decodeBase16ToArray(): ByteArray? {
     }
 
     if (limit == 0) {
-        return null
+        return ByteArray(0)
     }
 
     val out: ByteArray = ByteArray(limit / 2)

--- a/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
+++ b/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
@@ -118,7 +118,7 @@ fun CharArray.decodeBase32ToArray(base32: Base32 = Base32.Default): ByteArray? {
 
     // Was all padding, whitespace, or otherwise ignorable characters
     if (limit == 0) {
-        return null
+        return ByteArray(0)
     }
 
     val out: ByteArray = ByteArray((limit * 5L / 8L).toInt())

--- a/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32CrockfordUnitTest.kt
+++ b/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32CrockfordUnitTest.kt
@@ -19,7 +19,6 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
         Data(raw = "auu", expected = null, message = "Character 'u' should return null"),
         Data(raw = "UA", expected = null, message = "Character 'U' should return null"),
         Data(raw = "ua", expected = null, message = "Character 'u' should return null"),
-        Data(raw = "-----", expected = null, message = "String of only hyphens '-' should return null"),
     )
 
     companion object {
@@ -33,6 +32,7 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
     override val decodeSuccessDataSet: Set<Data<String, ByteArray>> = setOf(
         decodeSuccessHelloWorld,
         Data(raw = " 91JP RV3F41B PYW KCC GGG  ", expected = "Hello World!".encodeToByteArray(), message = "Spaces ' ' should be ignored"),
+        Data(raw = "-----", expected = ByteArray(0), message = "Decoding a String containing only hyphens '-' should return an empty ByteArray"),
 
         Data(raw = "CR", expected = "f".encodeToByteArray()),
         Data(raw = "cR", expected = "f".encodeToByteArray(), message = MESSAGE_LOWERCASE),

--- a/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32DefaultUnitTest.kt
+++ b/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32DefaultUnitTest.kt
@@ -17,6 +17,7 @@ class Base32DefaultUnitTest: BaseEncodingTestBase() {
 
     override val decodeSuccessDataSet: Set<Data<String, ByteArray>> = setOf(
         decodeSuccessHelloWorld,
+        Data(raw = "========", expected = ByteArray(0), message = "Decoding a String containing only padding '=' should return an empty ByteArray"),
         Data(raw = "MY======", expected = "f".encodeToByteArray()),
         Data(raw = "MY", expected = "f".encodeToByteArray(), message = "Stripped padding should decode"),
         Data(raw = "MZXQ====", expected = "fo".encodeToByteArray()),

--- a/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32HexUnitTest.kt
+++ b/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32HexUnitTest.kt
@@ -18,6 +18,7 @@ class Base32HexUnitTest: BaseEncodingTestBase() {
 
     override val decodeSuccessDataSet: Set<Data<String, ByteArray>> = setOf(
         decodeSuccessHelloWorld,
+        Data(raw = "======", expected = ByteArray(0), message = "Decoding a String containing only padding '=' should return an empty ByteArray"),
         Data(raw = "CO======", expected = "f".encodeToByteArray()),
         Data(raw = "CO", expected = "f".encodeToByteArray(), message = "Stripped padding should decode"),
         Data(raw = "CPNG====", expected = "fo".encodeToByteArray()),

--- a/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
+++ b/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
@@ -93,7 +93,7 @@ fun CharArray.decodeBase64ToArray(): ByteArray? {
 
     // Was all padding, whitespace, or otherwise ignorable characters
     if (limit == 0) {
-        return null
+        return ByteArray(0)
     }
 
     // If the input includes whitespace, this output array will be longer than necessary.

--- a/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64DefaultUnitTest.kt
+++ b/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64DefaultUnitTest.kt
@@ -45,6 +45,7 @@ class Base64DefaultUnitTest: BaseEncodingTestBase() {
             expected = ("53 61 6c 74 65 64 5f 5f f3 94 90 6e fa 9d 10 f1 b1 df e0 0f 40 15 01 " +
                     "3a 97 ec 1f 48 ba 76 ad a9").decodeHexToByteArray()
         ),
+        Data(raw = "======", expected = ByteArray(0), message = "Decoding a String containing only padding '=' should return an empty ByteArray"),
         Data(raw = "Zg==", expected = "f".encodeToByteArray()),
         Data(raw = "Zm8=", expected = "fo".encodeToByteArray()),
         Data(raw = "Zm9v", expected = "foo".encodeToByteArray()),

--- a/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64UrlSafeUnitTest.kt
+++ b/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64UrlSafeUnitTest.kt
@@ -43,6 +43,7 @@ class Base64UrlSafeUnitTest: BaseEncodingTestBase() {
             expected = ("53 61 6c 74 65 64 5f 5f f3 94 90 6e fa 9d 10 f1 b1 df e0 0f 40 15 01 " +
                     "3a 97 ec 1f 48 ba 76 ad a9").decodeHexToByteArray()
         ),
+        Data(raw = "======", expected = ByteArray(0), message = "Decoding a String containing only padding '=' should return an empty ByteArray"),
         Data(raw = "Zg==", expected = "f".encodeToByteArray()),
         Data(raw = "Zm8=", expected = "fo".encodeToByteArray()),
         Data(raw = "Zm9v", expected = "foo".encodeToByteArray()),

--- a/encoding-test/src/commonMain/kotlin/io/matthewnelson/component/encoding/test/BaseEncodingTestBase.kt
+++ b/encoding-test/src/commonMain/kotlin/io/matthewnelson/component/encoding/test/BaseEncodingTestBase.kt
@@ -2,6 +2,7 @@ package io.matthewnelson.component.encoding.test
 
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 abstract class BaseEncodingTestBase {
 
@@ -71,21 +72,23 @@ abstract class BaseEncodingTestBase {
     }
 
     protected fun checkUniversalDecoderParameters() {
-        assertNull(
-            actual = decode(""),
-            message = "Decoding an empty String should return null"
+        val emptyDecode = decode("")
+        assertTrue(
+            actual = emptyDecode?.isEmpty() == true,
+            message = "Decoding an empty String should return an empty ByteArray"
         )
-        assertNull(
-            actual = decode("      "),
-            message = "Decoding a String with all spaces should return null"
+        val emptyDecode2 = decode("      ")
+        assertTrue(
+            actual = emptyDecode2?.isEmpty() == true,
+            message = "Decoding a String with all spaces should return an empty ByteArray"
         )
 
-        // For Base32.Crockford, the standard '=' padding is only accepted when
-        // appended as a check symbol, so checking here for all other decoders is ok
-        assertNull(
-            actual = decode("=="),
-            message = "Decoding a String containing only padding '=' should return null"
-        )
+//        // For Base32.Crockford, the standard '=' padding is only accepted when
+//        // appended as a check symbol, so checking here for all other decoders is ok
+//        assertNull(
+//            actual = decode("=="),
+//            message = "Decoding a String containing only padding '=' should return null"
+//        )
 
         val newHelloWorldEncodedString = decodeSuccessHelloWorld.raw.let { string ->
             val sb = StringBuilder()


### PR DESCRIPTION
Decoding an empty string or character array was returning null, while decoding an empty byte array was returning an empty string/char array.

This remedies the error by returning an empty ByteArray instead of null in the event of an empty string/chararray.