### PR TITLE
Remove Android target

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,12 +43,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }
 

--- a/encoding-base16/build.gradle.kts
+++ b/encoding-base16/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -25,21 +24,7 @@ plugins {
 kmpConfiguration {
     setupMultiplatform(
         setOf(
-            KmpTarget.Jvm.Jvm.DEFAULT,
-
-            KmpTarget.Jvm.Android(
-                buildTools = versions.android.buildTools,
-                compileSdk = versions.android.sdkCompile,
-                minSdk = versions.android.sdkMin16,
-
-                /* Compile to Java 1.8 so inline functions work with non Java 11 apps */
-                compileSourceOption = JavaVersion.VERSION_1_8,
-                compileTargetOption = JavaVersion.VERSION_1_8,
-                kotlinJvmTarget = JavaVersion.VERSION_1_8,
-                target = {
-                    publishLibraryVariants("release")
-                }
-            ),
+            KmpTarget.Jvm.Jvm(kotlinJvmTarget = JavaVersion.VERSION_1_8),
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,

--- a/encoding-base32/build.gradle.kts
+++ b/encoding-base32/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -25,21 +24,7 @@ plugins {
 kmpConfiguration {
     setupMultiplatform(
         setOf(
-            KmpTarget.Jvm.Jvm.DEFAULT,
-
-            KmpTarget.Jvm.Android(
-                buildTools = versions.android.buildTools,
-                compileSdk = versions.android.sdkCompile,
-                minSdk = versions.android.sdkMin16,
-
-                /* Compile to Java 1.8 so inline functions work with non Java 11 apps */
-                compileSourceOption = JavaVersion.VERSION_1_8,
-                compileTargetOption = JavaVersion.VERSION_1_8,
-                kotlinJvmTarget = JavaVersion.VERSION_1_8,
-                target = {
-                    publishLibraryVariants("release")
-                }
-            ),
+            KmpTarget.Jvm.Jvm(kotlinJvmTarget = JavaVersion.VERSION_1_8),
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,

--- a/encoding-base64/build.gradle.kts
+++ b/encoding-base64/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -25,21 +24,7 @@ plugins {
 kmpConfiguration {
     setupMultiplatform(
         setOf(
-            KmpTarget.Jvm.Jvm.DEFAULT,
-
-            KmpTarget.Jvm.Android(
-                buildTools = versions.android.buildTools,
-                compileSdk = versions.android.sdkCompile,
-                minSdk = versions.android.sdkMin16,
-
-                /* Compile to Java 1.8 so inline functions work with non Java 11 apps */
-                compileSourceOption = JavaVersion.VERSION_1_8,
-                compileTargetOption = JavaVersion.VERSION_1_8,
-                kotlinJvmTarget = JavaVersion.VERSION_1_8,
-                target = {
-                    publishLibraryVariants("release")
-                }
-            ),
+            KmpTarget.Jvm.Jvm(kotlinJvmTarget = JavaVersion.VERSION_1_8),
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,

--- a/encoding-test/build.gradle.kts
+++ b/encoding-test/build.gradle.kts
@@ -1,4 +1,3 @@
-import io.matthewnelson.kotlin.components.dependencies.versions
 import io.matthewnelson.kotlin.components.kmp.KmpTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -9,13 +8,7 @@ plugins {
 kmpConfiguration {
     setupMultiplatform(
         setOf(
-            KmpTarget.Jvm.Jvm.DEFAULT,
-
-            KmpTarget.Jvm.Android(
-                buildTools = versions.android.buildTools,
-                compileSdk = versions.android.sdkCompile,
-                minSdk = versions.android.sdkMin16,
-            ),
+            KmpTarget.Jvm.Jvm(kotlinJvmTarget = JavaVersion.VERSION_1_8),
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ kapt.use.worker.api=true
 kotlin.mpp.stability.nowarn=true
 
 kotlin.native.enableDependencyPropagation=false
+kotlin.native.ignoreDisabledTargets=true
 
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.enableCompatibilityMetadataVariant=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,5 +5,5 @@ zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 
 # https://gradle.org/release-checksums/
-distributionSha256Sum=a8da5b02437a60819cad23e10fc7e9cf32bcb57029d9cb277e26eeff76ce014b
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionSha256Sum=b75392c5625a88bccd58a574552a5a323edca82dab5942d2d41097f809c6bcce
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ include(":encoding-test")
 private val KMP_TARGETS: String? by settings
 @Suppress("PrivatePropertyName")
 private val KMP_TARGETS_ALL: String? by settings
-if (KMP_TARGETS_ALL != null || KMP_TARGETS?.split(',')?.contains("ANDROID") != false) {
+if (KMP_TARGETS_ALL != null || KMP_TARGETS?.split(',')?.contains("JVM") != false) {
     include(":app")
 }
 

--- a/tools/check-publication/build.gradle.kts
+++ b/tools/check-publication/build.gradle.kts
@@ -41,14 +41,7 @@ kmpPublishRootProjectConfiguration?.let { config ->
 kmpConfiguration {
     setupMultiplatform(
         setOf(
-
-            KmpTarget.Jvm.Jvm.DEFAULT,
-
-            KmpTarget.Jvm.Android(
-                buildTools = versions.android.buildTools,
-                compileSdk = versions.android.sdkCompile,
-                minSdk = versions.android.sdkMin16,
-            ),
+            KmpTarget.Jvm.Jvm(kotlinJvmTarget = JavaVersion.VERSION_1_8),
 
             KmpTarget.NonJvm.JS(
                 compilerType = KotlinJsCompilerType.BOTH,


### PR DESCRIPTION
Resolves #5 

* bump kotlin-components to latest master branch commit

* bump gradle wrapper from 7.2 -> 7.3.1

* add flag to disable warning

* remove Android kmp target in favor of compiling java with version 1.8

* set sample app java target to version 11

* remove android target from check publication module