### PR TITLE
Implement common encoding/decoding logic for `encoding-core`

### DIFF
--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -1,5 +1,6 @@
 public abstract class io/matthewnelson/encoding/core/Decoder {
 	public static final field Companion Lio/matthewnelson/encoding/core/Decoder$Companion;
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun decodeToArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
@@ -7,6 +8,7 @@ public abstract class io/matthewnelson/encoding/core/Decoder {
 	public static final fun decodeToArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
 	public abstract fun decodedOutMaxSize (I)I
+	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;
 	public abstract fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
 	public fun quickAnalysisIsValid (Ljava/lang/String;)V
 	public fun quickAnalysisIsValid ([B)V
@@ -34,6 +36,7 @@ public abstract class io/matthewnelson/encoding/core/Decoder$Feed {
 
 public abstract class io/matthewnelson/encoding/core/Encoder : io/matthewnelson/encoding/core/Decoder {
 	public static final field Companion Lio/matthewnelson/encoding/core/Encoder$Companion;
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun encodeToByteArray ([BLio/matthewnelson/encoding/core/Encoder;)[B
 	public static final fun encodeToCharArray ([BLio/matthewnelson/encoding/core/Encoder;)[C
 	public static final fun encodeToString ([BLio/matthewnelson/encoding/core/Encoder;)Ljava/lang/String;
@@ -55,6 +58,24 @@ public abstract class io/matthewnelson/encoding/core/Encoder$Feed {
 	public final fun toString ()Ljava/lang/String;
 	public final fun update (B)V
 	protected abstract fun updateProtected (B)V
+}
+
+public abstract class io/matthewnelson/encoding/core/EncoderDecoder : io/matthewnelson/encoding/core/Encoder {
+	public fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public final fun hashCode ()I
+	protected abstract fun name ()Ljava/lang/String;
+	public final fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+	public final field isLenient Z
+	public final field paddingChar Ljava/lang/Character;
+	public fun <init> (ZLjava/lang/Character;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public final fun hashCode ()I
+	public final fun toString ()Ljava/lang/String;
+	protected abstract fun toString (Ljava/lang/StringBuilder;)V
 }
 
 public final class io/matthewnelson/encoding/core/EncodingException : java/lang/RuntimeException {

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -65,12 +65,12 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder : io/matthew
 
 public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
 	public final field isLenient Z
-	public final field paddingChar Ljava/lang/Character;
 	public fun <init> (ZLjava/lang/Character;)V
 	public abstract fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 	public abstract fun encodeOutSize (I)I
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
+	public final fun paddingChar ()Ljava/lang/Character;
 	public final fun toString ()Ljava/lang/String;
 	protected abstract fun toString (Ljava/lang/StringBuilder;)V
 }
@@ -89,8 +89,8 @@ public abstract interface class io/matthewnelson/encoding/core/OutFeed {
 }
 
 public final class io/matthewnelson/encoding/core/internal/ByteChar$Companion {
-	public final fun toByteChar-qQkxe1M (B)Ljava/lang/Object;
-	public final fun toByteChar-qQkxe1M (C)Ljava/lang/Object;
+	public final fun toByteChar-qQkxe1M (B)B
+	public final fun toByteChar-qQkxe1M (C)B
 }
 
 public final class io/matthewnelson/encoding/core/internal/EncodingTable$Companion {

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -7,12 +7,8 @@ public abstract class io/matthewnelson/encoding/core/Decoder {
 	public static final fun decodeToArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
-	public abstract fun decodedOutMaxSize (I)I
 	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;
 	public abstract fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
-	public fun quickAnalysisIsValid (Ljava/lang/String;)V
-	public fun quickAnalysisIsValid ([B)V
-	public fun quickAnalysisIsValid ([C)V
 }
 
 public final class io/matthewnelson/encoding/core/Decoder$Companion {
@@ -40,7 +36,6 @@ public abstract class io/matthewnelson/encoding/core/Encoder : io/matthewnelson/
 	public static final fun encodeToByteArray ([BLio/matthewnelson/encoding/core/Encoder;)[B
 	public static final fun encodeToCharArray ([BLio/matthewnelson/encoding/core/Encoder;)[C
 	public static final fun encodeToString ([BLio/matthewnelson/encoding/core/Encoder;)Ljava/lang/String;
-	public abstract fun encodedOutSize (I)I
 	public abstract fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
 
@@ -72,6 +67,8 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Configuratio
 	public final field isLenient Z
 	public final field paddingChar Ljava/lang/Character;
 	public fun <init> (ZLjava/lang/Character;)V
+	public abstract fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+	public abstract fun encodeOutSize (I)I
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public final fun toString ()Ljava/lang/String;
@@ -101,5 +98,14 @@ public final class io/matthewnelson/encoding/core/internal/EncodingTable$Compani
 }
 
 public abstract interface annotation class io/matthewnelson/encoding/core/internal/InternalEncodingApi : java/lang/annotation/Annotation {
+}
+
+public final class io/matthewnelson/encoding/core/util/DecoderInput {
+	public static final field Companion Lio/matthewnelson/encoding/core/util/DecoderInput$Companion;
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun get (I)C
+}
+
+public final class io/matthewnelson/encoding/core/util/DecoderInput$Companion {
 }
 

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -1,4 +1,82 @@
+public abstract class io/matthewnelson/encoding/core/Decoder {
+	public static final field Companion Lio/matthewnelson/encoding/core/Decoder$Companion;
+	public static final fun decodeToArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
+	public abstract fun decodedOutMaxSize (I)I
+	public abstract fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
+	public fun quickAnalysisIsValid (Ljava/lang/String;)V
+	public fun quickAnalysisIsValid ([B)V
+	public fun quickAnalysisIsValid ([C)V
+}
+
+public final class io/matthewnelson/encoding/core/Decoder$Companion {
+	public final fun decodeToArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
+}
+
+public abstract class io/matthewnelson/encoding/core/Decoder$Feed {
+	public fun <init> (Lio/matthewnelson/encoding/core/Decoder;)V
+	public final fun doFinal ()V
+	protected abstract fun doFinalProtected ()V
+	public final fun isClosed ()Z
+	public final fun toString ()Ljava/lang/String;
+	public final fun update (C)V
+	protected abstract fun updateProtected (C)V
+}
+
+public abstract class io/matthewnelson/encoding/core/Encoder : io/matthewnelson/encoding/core/Decoder {
+	public static final field Companion Lio/matthewnelson/encoding/core/Encoder$Companion;
+	public static final fun encodeToByteArray ([BLio/matthewnelson/encoding/core/Encoder;)[B
+	public static final fun encodeToCharArray ([BLio/matthewnelson/encoding/core/Encoder;)[C
+	public static final fun encodeToString ([BLio/matthewnelson/encoding/core/Encoder;)Ljava/lang/String;
+	public abstract fun encodedOutSize (I)I
+	public abstract fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+}
+
+public final class io/matthewnelson/encoding/core/Encoder$Companion {
+	public final fun encodeToByteArray ([BLio/matthewnelson/encoding/core/Encoder;)[B
+	public final fun encodeToCharArray ([BLio/matthewnelson/encoding/core/Encoder;)[C
+	public final fun encodeToString ([BLio/matthewnelson/encoding/core/Encoder;)Ljava/lang/String;
+}
+
+public abstract class io/matthewnelson/encoding/core/Encoder$Feed {
+	public fun <init> (Lio/matthewnelson/encoding/core/Encoder;)V
+	public final fun doFinal ()V
+	protected abstract fun doFinalProtected ()V
+	public final fun isClosed ()Z
+	public final fun toString ()Ljava/lang/String;
+	public final fun update (B)V
+	protected abstract fun updateProtected (B)V
+}
+
+public final class io/matthewnelson/encoding/core/EncodingException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun getMessage ()Ljava/lang/String;
+}
+
 public abstract interface annotation class io/matthewnelson/encoding/core/ExperimentalEncodingApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class io/matthewnelson/encoding/core/OutFeed {
+	public abstract fun invoke (B)V
+}
+
+public final class io/matthewnelson/encoding/core/internal/ByteChar$Companion {
+	public final fun toByteChar-qQkxe1M (B)Ljava/lang/Object;
+	public final fun toByteChar-qQkxe1M (C)Ljava/lang/Object;
+}
+
+public final class io/matthewnelson/encoding/core/internal/EncodingTable$Companion {
+	public final fun from-T0v-vo0 (Ljava/lang/String;)[B
 }
 
 public abstract interface annotation class io/matthewnelson/encoding/core/internal/InternalEncodingApi : java/lang/annotation/Annotation {

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package io.matthewnelson.encoding.core
+
+import io.matthewnelson.encoding.core.internal.closedException
+import kotlin.jvm.JvmStatic
+
+/**
+ * Decode things.
+ *
+ * @see [decodeToArray]
+ * @see [decodeToArrayOrNull]
+ * @see [Feed]
+ * @see [newDecoderFeed]
+ * */
+public sealed class Decoder {
+
+    // TODO: These should be moved to the Configuration
+    //  and instead accept a wrapper class which holds
+    //  Any. Then based off of the configuration it can
+    //  be determined whether or not the it is a valid
+    //  encoding for the encoder so we can quit early.
+    //  .
+    //  Maybe the config generates Regex or something once
+    //  it's instantiated, based off of the options that
+    //  are set???
+    @ExperimentalEncodingApi
+    @Throws(EncodingException::class)
+    public open fun quickAnalysisIsValid(encoded: String) {}
+    @ExperimentalEncodingApi
+    @Throws(EncodingException::class)
+    public open fun quickAnalysisIsValid(encoded: CharArray) {}
+    @ExperimentalEncodingApi
+    @Throws(EncodingException::class)
+    public open fun quickAnalysisIsValid(encoded: ByteArray) {}
+
+    // TODO: This should be moved to the Configuration
+    //  and instead accept a wrapper class which holds
+    //  Any.
+    public abstract fun decodedOutMaxSize(inSize: Int): Int
+
+    /**
+     * Creates a new [Decoder.Feed] for the [Decoder], outputting
+     * decoded bytes to the provided [OutFeed].
+     *
+     * @see [Decoder.Feed]
+     * */
+    @ExperimentalEncodingApi
+    public abstract fun newDecoderFeed(out: OutFeed): Decoder.Feed
+
+    /**
+     * Encoded data goes into [update], and upon the [Decoder]
+     * implementation's buffer filling, decoded data is fed
+     * to [OutFeed] allowing for a "lazy" decode and streaming.
+     *
+     * Once all the data has been submitted via [update], call
+     * [doFinal] to close the [Feed] which is where the [Decoder]
+     * will finalize the decoding and check for correctness.
+     * */
+    public abstract inner class Feed
+    @ExperimentalEncodingApi
+    constructor() {
+
+        public var isClosed: Boolean = false
+            private set
+
+        @Throws(EncodingException::class)
+        protected abstract fun updateProtected(c: Char)
+        @Throws(EncodingException::class)
+        protected abstract fun doFinalProtected()
+
+        @ExperimentalEncodingApi
+        @Throws(EncodingException::class)
+        public fun update(c: Char) {
+            if (isClosed) throw closedException()
+            updateProtected(c)
+        }
+
+        @ExperimentalEncodingApi
+        @Throws(EncodingException::class)
+        public fun doFinal() {
+            if (isClosed) throw closedException()
+            isClosed = true
+            doFinalProtected()
+        }
+
+        final override fun toString(): String = "${this@Decoder}.Decoder.Feed@${hashCode()}"
+    }
+
+    public companion object {
+
+        /**
+         * Decodes a [String] for the provided [decoder] and
+         * returns the decoded bytes.
+         *
+         * @see [decodeToArrayOrNull]
+         * @throws [EncodingException] if decoding failed.
+         * */
+        @JvmStatic
+        @Throws(EncodingException::class)
+        @OptIn(ExperimentalEncodingApi::class)
+        public fun String.decodeToArray(decoder: Decoder): ByteArray {
+            decoder.quickAnalysisIsValid(this)
+            return decoder.decode(length) {
+                forEach { char ->
+                    update(char)
+                }
+            }
+        }
+
+        @JvmStatic
+        public fun String.decodeToArrayOrNull(decoder: Decoder): ByteArray? {
+            return try {
+                decodeToArray(decoder)
+            } catch (e: EncodingException) {
+                null
+            }
+        }
+
+        /**
+         * Decodes a [CharArray] for the provided [decoder] and
+         * returns the decoded bytes.
+         *
+         * @see [decodeToArrayOrNull]
+         * @throws [EncodingException] if decoding failed.
+         * */
+        @JvmStatic
+        @Throws(EncodingException::class)
+        @OptIn(ExperimentalEncodingApi::class)
+        public fun CharArray.decodeToArray(decoder: Decoder): ByteArray {
+            decoder.quickAnalysisIsValid(this)
+            return decoder.decode(size) {
+                forEach { char ->
+                    update(char)
+                }
+            }
+        }
+
+        @JvmStatic
+        public fun CharArray.decodeToArrayOrNull(decoder: Decoder): ByteArray? {
+            return try {
+                decodeToArray(decoder)
+            } catch (e: EncodingException) {
+                null
+            }
+        }
+
+        /**
+         * Decodes a [ByteArray] for the provided [decoder] and
+         * returns the decoded bytes.
+         *
+         * @see [decodeToArrayOrNull]
+         * @throws [EncodingException] if decoding failed.
+         * */
+        @JvmStatic
+        @Throws(EncodingException::class)
+        @OptIn(ExperimentalEncodingApi::class)
+        public fun ByteArray.decodeToArray(decoder: Decoder): ByteArray {
+            decoder.quickAnalysisIsValid(this)
+            return decoder.decode(size) {
+                forEach { byte ->
+                    update(byte.toInt().toChar())
+                }
+            }
+        }
+
+        @JvmStatic
+        public fun ByteArray.decodeToArrayOrNull(decoder: Decoder): ByteArray? {
+            return try {
+                decodeToArray(decoder)
+            } catch (_: EncodingException) {
+                null
+            }
+        }
+
+        @Throws(EncodingException::class)
+        @OptIn(ExperimentalEncodingApi::class)
+        private fun Decoder.decode(length: Int, update: Decoder.Feed.() -> Unit): ByteArray {
+            val size = decodedOutMaxSize(length)
+            val ba = ByteArray(size)
+
+            var i = 0
+            val feed = newDecoderFeed { byte ->
+                ba[i++] = byte
+            }
+
+            update.invoke(feed)
+            feed.doFinal()
+
+            return if (i == size) {
+                ba
+            } else {
+                ba.copyOf(i)
+            }
+        }
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -28,7 +28,7 @@ import kotlin.jvm.JvmStatic
  * @see [Feed]
  * @see [newDecoderFeed]
  * */
-public sealed class Decoder {
+public sealed class Decoder(public val config: EncoderDecoder.Configuration) {
 
     // TODO: These should be moved to the Configuration
     //  and instead accept a wrapper class which holds

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -29,7 +29,7 @@ import kotlin.jvm.JvmStatic
  * @see [Feed]
  * @see [newEncoderFeed]
  * */
-public sealed class Encoder: Decoder() {
+public sealed class Encoder(config: EncoderDecoder.Configuration): Decoder(config) {
 
     // TODO: This should be moved to the Configuration
     //  and instead accept a wrapper class which holds

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -17,6 +17,8 @@
 
 package io.matthewnelson.encoding.core
 
+import io.matthewnelson.encoding.core.internal.ByteChar.Companion.toByteChar
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 import io.matthewnelson.encoding.core.internal.closedException
 import kotlin.jvm.JvmStatic
 
@@ -85,11 +87,11 @@ public sealed class Encoder(config: EncoderDecoder.Configuration): Decoder(confi
          * returns the encoded data in the form of a [String].
          * */
         @JvmStatic
+        @OptIn(InternalEncodingApi::class)
         public fun ByteArray.encodeToString(encoder: Encoder): String {
             val sb = StringBuilder(encoder.config.encodeOutSize(size))
-
             encoder.encode(this) { byte ->
-                sb.append(byte.toInt().toChar())
+                sb.append(byte.toByteChar().char)
             }
             return sb.toString()
         }
@@ -99,12 +101,12 @@ public sealed class Encoder(config: EncoderDecoder.Configuration): Decoder(confi
          * returns the encoded data in the form of a [CharArray].
          * */
         @JvmStatic
+        @OptIn(InternalEncodingApi::class)
         public fun ByteArray.encodeToCharArray(encoder: Encoder): CharArray {
             val ca = CharArray(encoder.config.encodeOutSize(size))
-
             var i = 0
             encoder.encode(this) { byte ->
-                ca[i++] = byte.toInt().toChar()
+                ca[i++] = byte.toByteChar().char
             }
             return ca
         }
@@ -116,7 +118,6 @@ public sealed class Encoder(config: EncoderDecoder.Configuration): Decoder(confi
         @JvmStatic
         public fun ByteArray.encodeToByteArray(encoder: Encoder): ByteArray {
             val ba = ByteArray(encoder.config.encodeOutSize(size))
-
             var i = 0
             encoder.encode(this) { byte ->
                 ba[i++] = byte

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package io.matthewnelson.encoding.core
+
+import io.matthewnelson.encoding.core.internal.closedException
+import kotlin.jvm.JvmStatic
+
+/**
+ * Encode things.
+ *
+ * @see [encodeToString]
+ * @see [encodeToCharArray]
+ * @see [encodeToByteArray]
+ * @see [Feed]
+ * @see [newEncoderFeed]
+ * */
+public sealed class Encoder: Decoder() {
+
+    // TODO: This should be moved to the Configuration
+    //  and instead accept a wrapper class which holds
+    //  Any.
+    public abstract fun encodedOutSize(inSize: Int): Int
+
+    /**
+     * Creates a new [Encoder.Feed] for the [Encoder], outputting
+     * encoded bytes to the provided [OutFeed].
+     *
+     * @see [Encoder.Feed]
+     * */
+    @ExperimentalEncodingApi
+    public abstract fun newEncoderFeed(out: OutFeed): Encoder.Feed
+
+    /**
+     * Data goes into [update], and upon the [Encoder]
+     * implementation's buffer filling, encoded data is fed
+     * to [OutFeed] allowing for a "lazy" encode and streaming.
+     *
+     * Once all the data has been submitted via [update], call
+     * [doFinal] to close the [Feed] which is where the [Encoder]
+     * will finalize the encoding (such as applying padding, if
+     * specified)
+     * */
+    public abstract inner class Feed
+    @ExperimentalEncodingApi
+    constructor() {
+
+        public var isClosed: Boolean = false
+            private set
+
+        protected abstract fun updateProtected(b: Byte)
+        protected abstract fun doFinalProtected()
+
+        @ExperimentalEncodingApi
+        @Throws(EncodingException::class)
+        public fun update(b: Byte) {
+            if (isClosed) throw closedException()
+            updateProtected(b)
+        }
+
+        @ExperimentalEncodingApi
+        @Throws(EncodingException::class)
+        public fun doFinal() {
+            if (isClosed) throw closedException()
+            isClosed = true
+            doFinalProtected()
+        }
+
+        final override fun toString(): String = "${this@Encoder}.Encoder.Feed@${hashCode()}"
+    }
+
+    public companion object {
+
+        /**
+         * Encodes a [ByteArray] for the provided [encoder] and
+         * returns the encoded data in the form of a [String].
+         * */
+        @JvmStatic
+        public fun ByteArray.encodeToString(encoder: Encoder): String {
+            val sb = StringBuilder(encoder.encodedOutSize(size))
+            encoder.encode(this) { byte ->
+                sb.append(byte.toInt().toChar())
+            }
+            return sb.toString()
+        }
+
+        /**
+         * Encodes a [ByteArray] for the provided [encoder] and
+         * returns the encoded data in the form of a [CharArray].
+         * */
+        @JvmStatic
+        public fun ByteArray.encodeToCharArray(encoder: Encoder): CharArray {
+            val ca = CharArray(encoder.encodedOutSize(size))
+            var i = 0
+            encoder.encode(this) { byte ->
+                ca[i++] = byte.toInt().toChar()
+            }
+            return ca
+        }
+
+        /**
+         * Encodes a [ByteArray] for the provided [encoder] and
+         * returns the encoded data in the form of a [ByteArray].
+         * */
+        @JvmStatic
+        public fun ByteArray.encodeToByteArray(encoder: Encoder): ByteArray {
+            val ba = ByteArray(encoder.encodedOutSize(size))
+            var i = 0
+            encoder.encode(this) { byte ->
+                ba[i++] = byte
+            }
+            return ba
+        }
+
+        @OptIn(ExperimentalEncodingApi::class)
+        private fun Encoder.encode(bytes: ByteArray, out: OutFeed) {
+            val feed = newEncoderFeed(out)
+            for (byte in bytes) {
+                feed.update(byte)
+            }
+            feed.doFinal()
+        }
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("SpellCheckingInspection")
+
+package io.matthewnelson.encoding.core
+
+import kotlin.jvm.JvmField
+
+/**
+ * Base abstraction which expose [Encoder] and [Decoder] (sealed
+ * classes) such that inheriting classes must implement
+ * both.
+ *
+ * @see [Configuration]
+ * */
+public abstract class EncoderDecoder
+@ExperimentalEncodingApi
+constructor(config: Configuration): Encoder(config) {
+
+    /**
+     * Used in the [toString] output.
+     *
+     * e.g.
+     *
+     *   Base16
+     *   Base32.Hex
+     *   Base64.UrlSafe
+     * */
+    protected abstract fun name(): String
+
+    /**
+     * Base configuration for an [EncoderDecoder]. More options
+     * may be specified by the implementing class.
+     *
+     * @param [isLenient] If true, decoding will skip over spaces
+     *   and new lines ('\n', '\r', ' ', '\t'). If false, an
+     *   [EncodingException] will be thrown when encountering those
+     *   characters.
+     * @param [paddingChar] The character used when padding the
+     *   output for the given encoding; NOT "if padding should be
+     *   used". If the encoding specification does not ues padding,
+     *   pass `null`.
+     * */
+    public abstract class Configuration
+    @ExperimentalEncodingApi
+    constructor(
+        @JvmField
+        public val isLenient: Boolean,
+        @JvmField
+        public val paddingChar: Char?,
+    ) {
+
+        /**
+         * Will be called whenever [toString] is invoked, allowing
+         * inheritors of [Configuration] to add their settings to
+         * the output.
+         * */
+        protected abstract fun toString(sb: StringBuilder)
+
+        final override fun equals(other: Any?): Boolean {
+            return  other is Configuration
+                    && other::class == this::class
+                    && other.toString() == toString()
+        }
+
+        final override fun hashCode(): Int {
+            return 17 * 31 + toString().hashCode()
+        }
+
+        final override fun toString(): String {
+            return StringBuilder().apply {
+                append("EncoderDecoder.Configuration [")
+                appendLine()
+                append("    isLenient: ")
+                append(isLenient)
+                appendLine()
+                append("    paddingChar: ")
+                append(paddingChar)
+                appendLine()
+                toString(this)
+                appendLine()
+                append(']')
+            }.toString()
+        }
+    }
+
+    final override fun equals(other: Any?): Boolean {
+        return  other is EncoderDecoder
+                && other::class == this::class
+                && other.name() == name()
+                && other.config.hashCode() == config.hashCode()
+    }
+
+    final override fun hashCode(): Int {
+        var result = 17
+        result = result * 31 + toString().hashCode()
+        result = result * 31 + config.hashCode()
+        return result
+    }
+
+    final override fun toString(): String {
+        return "EncoderDecoder[${name()}]"
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -17,8 +17,12 @@
 
 package io.matthewnelson.encoding.core
 
+import io.matthewnelson.encoding.core.internal.ByteChar
+import io.matthewnelson.encoding.core.internal.ByteChar.Companion.toByteChar
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 import io.matthewnelson.encoding.core.util.DecoderInput
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmName
 
 /**
  * Base abstraction which expose [Encoder] and [Decoder] (sealed
@@ -55,14 +59,18 @@ constructor(config: Configuration): Encoder(config) {
      *   used". If the encoding specification does not ues padding,
      *   pass `null`.
      * */
+    @OptIn(InternalEncodingApi::class)
     public abstract class Configuration
     @ExperimentalEncodingApi
     constructor(
         @JvmField
         public val isLenient: Boolean,
-        @JvmField
-        public val paddingChar: Char?,
+        paddingChar: Char?,
     ) {
+
+        @InternalEncodingApi
+        public val paddingByteChar: ByteChar? = paddingChar?.toByteChar()
+        public fun paddingChar(): Char? = paddingByteChar?.char
 
         /**
          * Calculates and returns the maximum size of the output after
@@ -109,7 +117,7 @@ constructor(config: Configuration): Encoder(config) {
                 append(isLenient)
                 appendLine()
                 append("    paddingChar: ")
-                append(paddingChar)
+                append(paddingChar())
                 appendLine()
                 toString(this)
                 appendLine()

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -17,6 +17,7 @@
 
 package io.matthewnelson.encoding.core
 
+import io.matthewnelson.encoding.core.util.DecoderInput
 import kotlin.jvm.JvmField
 
 /**
@@ -31,10 +32,10 @@ public abstract class EncoderDecoder
 constructor(config: Configuration): Encoder(config) {
 
     /**
-     * Used in the [toString] output.
+     * The name of the [EncoderDecoder]. Utilized in the
+     * output of [toString].
      *
      * e.g.
-     *
      *   Base16
      *   Base32.Hex
      *   Base64.UrlSafe
@@ -62,6 +63,26 @@ constructor(config: Configuration): Encoder(config) {
         @JvmField
         public val paddingChar: Char?,
     ) {
+
+        /**
+         * Calculates and returns the maximum size of the output after
+         * decoding occurs, based off of the configuration options set
+         * for the [Configuration] implementation.
+         *
+         * @see [DecoderInput]
+         * @param [encodedSize] size of the data being decoded.
+         * @param [input] Provided for additional analysis in the event
+         *   the decoding specification has checks to fail early.
+         * */
+        @Throws(EncodingException::class)
+        public abstract fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int
+
+        /**
+         * Calculates and returns the size of the output after encoding
+         * occurs, based off of the configuration options set for the
+         * [Configuration] implementation.
+         * */
+        public abstract fun encodeOutSize(unencodedSize: Int): Int
 
         /**
          * Will be called whenever [toString] is invoked, allowing

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncodingException.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncodingException.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core
+
+public class EncodingException: RuntimeException {
+
+    override val message: String
+
+    public constructor(message: String): this(message, null)
+    public constructor(message: String, cause: Throwable?): super(message, cause) {
+        this.message = message
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/OutFeed.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/OutFeed.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core
+
+public fun interface OutFeed {
+    public fun invoke(byte: Byte)
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-Feed.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-Feed.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
+package io.matthewnelson.encoding.core.internal
+
+import io.matthewnelson.encoding.core.Decoder
+import io.matthewnelson.encoding.core.Encoder
+import io.matthewnelson.encoding.core.EncodingException
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Encoder.Feed.closedException(): EncodingException {
+    return EncodingException("$this is closed")
+}
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun Decoder.Feed.closedException(): EncodingException {
+    return EncodingException("$this is closed")
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/ByteChar.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/ByteChar.kt
@@ -22,30 +22,16 @@ import kotlin.jvm.JvmStatic
 
 @JvmInline
 @InternalEncodingApi
-public value class ByteChar private constructor(private val value: Any) {
+public value class ByteChar private constructor(public val byte: Byte) {
 
-    public val char: Char get() {
-        return if (value is Char) {
-            value
-        } else {
-            (value as Byte).toInt().toChar()
-        }
-    }
-
-    public val byte: Byte get() {
-        return if (value is Byte) {
-            value
-        } else {
-            (value as Char).code.toByte()
-        }
-    }
+    public val char: Char get() = byte.toInt().toChar()
 
     public fun lowercaseChar(): Char = char.lowercaseChar()
     public fun lowercaseByte(): Byte = lowercaseChar().code.toByte()
 
     public companion object {
         @JvmStatic
-        public fun Char.toByteChar(): ByteChar = ByteChar(this)
+        public fun Char.toByteChar(): ByteChar = ByteChar(this.code.toByte())
         @JvmStatic
         public fun Byte.toByteChar(): ByteChar = ByteChar(this)
     }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/ByteChar.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/ByteChar.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package io.matthewnelson.encoding.core.internal
+
+import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmStatic
+
+@JvmInline
+@InternalEncodingApi
+public value class ByteChar private constructor(private val value: Any) {
+
+    public val char: Char get() {
+        return if (value is Char) {
+            value
+        } else {
+            (value as Byte).toInt().toChar()
+        }
+    }
+
+    public val byte: Byte get() {
+        return if (value is Byte) {
+            value
+        } else {
+            (value as Char).code.toByte()
+        }
+    }
+
+    public fun lowercaseChar(): Char = char.lowercaseChar()
+    public fun lowercaseByte(): Byte = lowercaseChar().code.toByte()
+
+    public companion object {
+        @JvmStatic
+        public fun Char.toByteChar(): ByteChar = ByteChar(this)
+        @JvmStatic
+        public fun Byte.toByteChar(): ByteChar = ByteChar(this)
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/EncodingTable.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/EncodingTable.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core.internal
+
+import io.matthewnelson.encoding.core.internal.ByteChar.Companion.toByteChar
+import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmStatic
+
+@JvmInline
+@InternalEncodingApi
+public value class EncodingTable private constructor(private val value: ByteArray) {
+
+    @Throws(IndexOutOfBoundsException::class)
+    public fun get(index: Int): ByteChar = value[index].toByteChar()
+
+    public companion object {
+        @JvmStatic
+        public fun from(chars: String): EncodingTable = EncodingTable(chars.encodeToByteArray())
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core.util
+
+import io.matthewnelson.encoding.core.EncoderDecoder
+import io.matthewnelson.encoding.core.EncodingException
+import io.matthewnelson.encoding.core.internal.ByteChar.Companion.toByteChar
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Helper class for analyzing encoded data in order to
+ * determine the maximum output size based off of the
+ * options set for provided [EncoderDecoder.Configuration].
+ *
+ * Will "strip" padding (if the config specifies it) and
+ * spaces/new lines from the end in order to provide
+ * [EncoderDecoder.Configuration.decodeOutMaxSizeOrFail]
+ * with the best guess at input size.
+ *
+ * @see [get]
+ * @see [EncoderDecoder.Configuration.decodeOutMaxSizeOrFail]
+ * */
+@OptIn(InternalEncodingApi::class)
+public class DecoderInput
+@Throws(EncodingException::class)
+private constructor(
+    config: EncoderDecoder.Configuration,
+    private val input: Any
+) {
+
+    @get:JvmSynthetic
+    internal val decodeOutMaxSize: Int
+
+    /**
+     * Can be utilized by [EncoderDecoder.Configuration]
+     * implementation to check [input] in order to fail
+     * early.
+     * */
+    @Throws(EncodingException::class)
+    public fun get(index: Int): Char {
+        return try {
+            when (input) {
+                is String -> input[index]
+                is CharArray -> input[index]
+                else -> (input as ByteArray)[index].toByteChar().char
+            }
+        } catch (e: IndexOutOfBoundsException) {
+            throw EncodingException("Index out of bounds", e)
+        }
+    }
+
+    init {
+        var limit = when (input) {
+            is String -> input.length
+            is CharArray -> input.size
+            else -> (input as ByteArray).size
+        }
+
+        // Disregard any padding or spaces/new lines (if applicable)
+        while (limit > 0) {
+            when (get(limit - 1)) {
+                '\n', '\r', ' ', '\t' -> {
+                    if (!config.isLenient) {
+                        throw isLenientFalseEncodingException()
+                    } else {
+                        limit--
+                    }
+                }
+                config.paddingChar -> {
+                    limit--
+                }
+                else -> {
+                    break
+                }
+            }
+        }
+
+        val size = config.decodeOutMaxSizeOrFail(limit, this)
+
+        decodeOutMaxSize = if (size < 0) 0 else size
+    }
+
+    public companion object {
+
+        @JvmStatic
+        @InternalEncodingApi
+        public fun isLenientFalseEncodingException(): EncodingException {
+            return EncodingException("Spaces and new lines are forbidden when isLenient[false]")
+        }
+
+        @JvmSynthetic
+        @Throws(EncodingException::class)
+        internal fun String.toInputAnalysis(
+            config: EncoderDecoder.Configuration
+        ): DecoderInput = DecoderInput(config, this)
+
+        @JvmSynthetic
+        @Throws(EncodingException::class)
+        internal fun CharArray.toInputAnalysis(
+            config: EncoderDecoder.Configuration
+        ): DecoderInput = DecoderInput(config, this)
+
+        @JvmSynthetic
+        @Throws(EncodingException::class)
+        internal fun ByteArray.toInputAnalysis(
+            config: EncoderDecoder.Configuration
+        ): DecoderInput = DecoderInput(config, this)
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -73,21 +73,24 @@ private constructor(
 
         // Disregard any padding or spaces/new lines (if applicable)
         while (limit > 0) {
-            when (get(limit - 1)) {
+            val c = get(limit - 1)
+            when (c) {
                 '\n', '\r', ' ', '\t' -> {
                     if (!config.isLenient) {
                         throw isLenientFalseEncodingException()
                     } else {
                         limit--
+                        continue
                     }
                 }
-                config.paddingChar -> {
-                    limit--
-                }
-                else -> {
-                    break
-                }
             }
+
+            if (c.toByteChar() == config.paddingByteChar) {
+                limit--
+                continue
+            }
+
+            break
         }
 
         val size = config.decodeOutMaxSizeOrFail(limit, this)


### PR DESCRIPTION
Closes #39 

Introduces abstractions and tools for easily creating `EncoderDecoder`s.