### PR TITLE
Implement `base16` using `EncoderDecoder`

### DIFF
--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -6,3 +6,26 @@ public final class io/matthewnelson/component/encoding/base16/Base16Kt {
 	public static final fun encodeBase16ToCharArray ([B)[C
 }
 
+public final class io/matthewnelson/encoding/base16/Base16 : io/matthewnelson/encoding/core/EncoderDecoder {
+	public static final field CHARS Ljava/lang/String;
+	public static final field Companion Lio/matthewnelson/encoding/base16/Base16$Companion;
+	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Configuration;)V
+	public static final fun default ()Lio/matthewnelson/encoding/base16/Base16;
+	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
+	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+	public static final fun strict ()Lio/matthewnelson/encoding/base16/Base16;
+}
+
+public final class io/matthewnelson/encoding/base16/Base16$Companion {
+	public final fun default ()Lio/matthewnelson/encoding/base16/Base16;
+	public final fun strict ()Lio/matthewnelson/encoding/base16/Base16;
+}
+
+public final class io/matthewnelson/encoding/base16/Base16$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+	public final field decodeLowercase Z
+	public final field encodeToLowercase Z
+	public fun <init> (ZZZ)V
+	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+	public fun encodeOutSize (I)I
+}
+

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -13,117 +13,51 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress(
-    "KotlinRedundantDiagnosticSuppress",
-    "RedundantExplicitType",
-    "SpellCheckingInspection",
-)
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
 
 package io.matthewnelson.component.encoding.base16
 
-import kotlin.native.concurrent.SharedImmutable
+import io.matthewnelson.encoding.base16.Base16
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToArrayOrNull
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 
-@SharedImmutable
-private val HEX_TABLE = "0123456789ABCDEF".encodeToByteArray()
+@PublishedApi
+@InternalEncodingApi
+internal val COMPATIBILITY: Base16 = Base16(
+    Base16.Configuration(
+        isLenient = true,
+        decodeLowercase = false,
+        encodeToLowercase = false,
+    )
+)
 
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase16ToArray(): ByteArray? {
-    return toCharArray().decodeBase16ToArray()
+    @OptIn(InternalEncodingApi::class)
+    return decodeToArrayOrNull(COMPATIBILITY)
 }
 
 public fun CharArray.decodeBase16ToArray(): ByteArray? {
-    var limit = size
-    while (limit > 0) {
-        val c = this[limit - 1]
-        if (c != '\n' && c != '\r' && c != ' ' && c != '\t') {
-            break
-        }
-        limit--
-    }
-
-    if (limit == 0) {
-        return ByteArray(0)
-    }
-
-    val out: ByteArray = ByteArray(limit / 2)
-    var outCount: Int = 0
-    var inCount: Int = 0
-
-    var bitBuffer: Int = 0
-    for (i in 0 until limit) {
-        val c = this[i]
-
-        val bits: Int
-        when (c) {
-            in '0'..'9' -> {
-                // char ASCII value
-                // 0     48    0
-                // 9     57    9 (ASCII - 48)
-                bits = c.code - 48
-            }
-            in 'A'..'F' -> {
-                // char ASCII value
-                //   A   65    10
-                //   F   70    15 (ASCII - 55)
-                bits = c.code - 55
-            }
-            '\n', '\r', ' ', '\t' -> {
-                continue
-            }
-            else -> {
-                return null
-            }
-        }
-
-        // Append this char's 4 bits to the word
-        bitBuffer = bitBuffer shl 4 or bits
-
-        // For every 2 chars of input, we accumulate 8 bits of output data. Emit 1 byte
-        inCount++
-        if (inCount % 2 == 0) {
-            out[outCount++] = bitBuffer.toByte()
-        }
-    }
-
-    // 4*1 = 4 bits. Truncated, fail.
-    if (inCount % 2 != 0) {
-        return null
-    }
-
-    return if (outCount == out.size) {
-        out
-    } else {
-        out.copyOf(outCount)
-    }
+    @OptIn(InternalEncodingApi::class)
+    return decodeToArrayOrNull(COMPATIBILITY)
 }
 
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase16(): String {
-    return encodeBase16ToCharArray().joinToString("")
+    @OptIn(InternalEncodingApi::class)
+    return encodeToString(COMPATIBILITY)
 }
 
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase16ToCharArray(): CharArray {
-    return encodeBase16ToByteArray().let { bytes ->
-        val chars = CharArray(bytes.size)
-        for ((i, byte) in bytes.withIndex()) {
-            chars[i] = byte.toInt().toChar()
-        }
-        chars
-    }
+    @OptIn(InternalEncodingApi::class)
+    return encodeToCharArray(COMPATIBILITY)
 }
 
 public fun ByteArray.encodeBase16ToByteArray(): ByteArray {
-    val base16Lookup: ByteArray = HEX_TABLE
-
-    val out = ByteArray(size * 2)
-
-    var outCount = 0
-    for (byte in this) {
-        val bits = byte.toInt() and 0xff
-        out[outCount++] = base16Lookup[bits shr 4]
-        out[outCount++] = base16Lookup[bits and 0x0f]
-    }
-
-    return out
+    @OptIn(InternalEncodingApi::class)
+    return encodeToByteArray(COMPATIBILITY)
 }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("SpellCheckingInspection")
+
+package io.matthewnelson.encoding.base16
+
+import io.matthewnelson.encoding.core.*
+import io.matthewnelson.encoding.core.internal.EncodingTable
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+import io.matthewnelson.encoding.core.util.DecoderInput
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
+
+/**
+ * Base16 (aka "hex") encoding/decoding in accordance with
+ * RFC 4648 section 8.
+ * https://www.ietf.org/rfc/rfc4648.html#section-8
+ *
+ * @see [strict]
+ * @see [default]
+ * @see [Configuration]
+ * @see [CHARS]
+ * @see [EncoderDecoder]
+ * */
+@OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
+public class Base16(config: Configuration): EncoderDecoder(config) {
+
+    /**
+     * Configuration for [Base16] encoding/decoding.
+     *
+     * @param [isLenient] See [EncoderDecoder.Configuration]
+     * @param [decodeLowercase] If true, will also accept lowercase
+     *   characters when decoding (against RFC 4648).
+     * @param [encodeToLowercase] If true, will output lowercase
+     *   characters instead of uppercase (against RFC 4648).
+     * */
+    public class Configuration(
+        isLenient: Boolean,
+        @JvmField
+        public val decodeLowercase: Boolean,
+        @JvmField
+        public val encodeToLowercase: Boolean,
+    ): EncoderDecoder.Configuration(isLenient, paddingChar = null) {
+
+        override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int = encodedSize / 2
+        override fun encodeOutSize(unencodedSize: Int): Int = unencodedSize * 2
+
+        override fun toString(sb: StringBuilder) {
+            with(sb) {
+                append("    decodeLowercase: ")
+                append(decodeLowercase)
+                appendLine()
+                append("    encodeToLowercase: ")
+                append(encodeToLowercase)
+            }
+        }
+    }
+
+    public companion object {
+        public const val CHARS: String = "0123456789ABCDEF"
+
+        private val DEFAULT = Base16(Configuration(
+            isLenient = true,
+            decodeLowercase = true,
+            encodeToLowercase = true,
+        ))
+
+        private val STRICT = Base16(Configuration(
+            isLenient = false,
+            decodeLowercase = false,
+            encodeToLowercase = false,
+        ))
+
+        /**
+         * A default configuration for Base16 encoding/decoding where:
+         *  - [Configuration.isLenient] = true
+         *  - [Configuration.decodeLowercase] = true
+         *  - [Configuration.encodeToLowercase] = true
+         *
+         * ENCODING: Non-compliant with RFC 4648 section 8
+         * DECODING: Non-compliant with RFC 4648 section 8
+         * */
+        @JvmStatic
+        public fun default(): Base16 = DEFAULT
+
+        /**
+         * A strict configuration for Base16 encoding/decoding where:
+         *  - [Configuration.isLenient] = false
+         *  - [Configuration.decodeLowercase] = false
+         *  - [Configuration.encodeToLowercase] = false
+         *
+         * ENCODING: Compliant with RFC 4648 section 8
+         * DECODING: Compliant with RFC 4648 section 8
+         * */
+        @JvmStatic
+        public fun strict(): Base16 = STRICT
+
+        private val TABLE = EncodingTable.from(CHARS)
+    }
+
+    override fun newEncoderFeed(out: OutFeed): Feed {
+        return object : Encoder.Feed() {
+
+            override fun updateProtected(b: Byte) {
+                val bits = b.toInt() and 0xff
+                val b1 = TABLE.get(bits shr    4)
+                val b2 = TABLE.get(bits and 0x0f)
+
+                if ((config as Configuration).encodeToLowercase) {
+                    out.invoke(b1.lowercaseByte())
+                    out.invoke(b2.lowercaseByte())
+                } else {
+                    out.invoke(b1.byte)
+                    out.invoke(b2.byte)
+                }
+            }
+
+            override fun doFinalProtected() { /* no-op */ }
+        }
+    }
+
+    override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
+        return object : Decoder.Feed() {
+            private var count = 0
+            private var bitBuffer = 0
+
+            @Throws(EncodingException::class)
+            override fun updateProtected(c: Char) {
+                val char = if ((config as Configuration).decodeLowercase) {
+                    c.uppercaseChar()
+                } else {
+                    c
+                }
+
+                val bits: Int
+                when (char) {
+                    in '0'..'9' -> {
+                        // char ASCII value
+                        // 0     48    0
+                        // 9     57    9 (ASCII - 48)
+                        bits = c.code - 48
+                    }
+                    in 'A'..'F' -> {
+                        // char ASCII value
+                        //   A   65    10
+                        //   F   70    15 (ASCII - 55)
+                        bits = c.code - 55
+                    }
+                    '\n', '\r', ' ', '\t' -> {
+                        if (config.isLenient) {
+                            return
+                        } else {
+                            throw DecoderInput.isLenientFalseEncodingException()
+                        }
+                    }
+                    else -> {
+                        throw EncodingException("Char[$c] is not a valid Base16 character")
+                    }
+                }
+
+                bitBuffer = bitBuffer shl 4 or bits
+
+                if (++count % 2 == 0) {
+                    out.invoke(bitBuffer.toByte())
+                    count = 0
+                    bitBuffer = 0
+                }
+            }
+
+            @Throws(EncodingException::class)
+            override fun doFinalProtected() {
+                // 4*1 = 4 bits. Truncated, fail.
+                val i = count % 2
+                if (i == 0) return
+                throw EncodingException("Truncated input. Count was $i when it should have been 0")
+            }
+        }
+    }
+
+    override fun name(): String = "Base16"
+}


### PR DESCRIPTION
Closes #28 
Closes #40 

Deprecation of old `base16` extension functions will occur in #43 