### PR TITLE
Stub in `Base32` migration to `EncoderDecoder`

### DIFF
--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -20,6 +20,7 @@ public final class io/matthewnelson/encoding/base16/Base16$Companion {
 public final class io/matthewnelson/encoding/base16/Base16$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
 	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
+	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
 
@@ -29,7 +30,7 @@ public final class io/matthewnelson/encoding/builders/Base16Builder {
 	public field isLenient Z
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Configuration;)V
-	public final fun build ()Lio/matthewnelson/encoding/base16/Base16;
+	public final fun build ()Lio/matthewnelson/encoding/base16/Base16$Configuration;
 }
 
 public final class io/matthewnelson/encoding/builders/Base16Kt {

--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -31,11 +31,14 @@ public final class io/matthewnelson/encoding/builders/Base16ConfigBuilder {
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Config;)V
 	public final fun build ()Lio/matthewnelson/encoding/base16/Base16$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/builders/Base16ConfigBuilder;
 }
 
 public final class io/matthewnelson/encoding/builders/Base16Kt {
 	public static final fun Base16 ()Lio/matthewnelson/encoding/base16/Base16;
 	public static final fun Base16 (Lio/matthewnelson/encoding/base16/Base16$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
 	public static final fun Base16 (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
+	public static final fun Base16 (Z)Lio/matthewnelson/encoding/base16/Base16;
+	public static synthetic fun Base16$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base16/Base16;
 }
 

--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -9,7 +9,7 @@ public final class io/matthewnelson/component/encoding/base16/Base16Kt {
 public final class io/matthewnelson/encoding/base16/Base16 : io/matthewnelson/encoding/core/EncoderDecoder {
 	public static final field CHARS Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base16/Base16$Companion;
-	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Configuration;)V
+	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
 	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
@@ -17,24 +17,25 @@ public final class io/matthewnelson/encoding/base16/Base16 : io/matthewnelson/en
 public final class io/matthewnelson/encoding/base16/Base16$Companion {
 }
 
-public final class io/matthewnelson/encoding/base16/Base16$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+public final class io/matthewnelson/encoding/base16/Base16$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
 	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
 
-public final class io/matthewnelson/encoding/builders/Base16Builder {
+public final class io/matthewnelson/encoding/builders/Base16ConfigBuilder {
 	public field acceptLowercase Z
 	public field encodeToLowercase Z
 	public field isLenient Z
 	public fun <init> ()V
-	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Configuration;)V
-	public final fun build ()Lio/matthewnelson/encoding/base16/Base16$Configuration;
+	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base16/Base16$Config;
 }
 
 public final class io/matthewnelson/encoding/builders/Base16Kt {
-	public static final fun Base16 (Lio/matthewnelson/encoding/base16/Base16$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
+	public static final fun Base16 ()Lio/matthewnelson/encoding/base16/Base16;
+	public static final fun Base16 (Lio/matthewnelson/encoding/base16/Base16$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
 	public static final fun Base16 (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
 }
 

--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -20,18 +20,20 @@ public final class io/matthewnelson/encoding/base16/Base16$Companion {
 public final class io/matthewnelson/encoding/base16/Base16$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
 	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
-	public fun <init> (ZZZ)V
 	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
-	public fun encodeOutSize (I)I
 }
 
 public final class io/matthewnelson/encoding/builders/Base16Builder {
 	public field acceptLowercase Z
 	public field encodeToLowercase Z
 	public field isLenient Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Configuration;)V
+	public final fun build ()Lio/matthewnelson/encoding/base16/Base16;
 }
 
 public final class io/matthewnelson/encoding/builders/Base16Kt {
+	public static final fun Base16 (Lio/matthewnelson/encoding/base16/Base16$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
 	public static final fun Base16 (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base16/Base16;
 }
 

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -18,6 +18,7 @@
 package io.matthewnelson.component.encoding.base16
 
 import io.matthewnelson.encoding.base16.Base16
+import io.matthewnelson.encoding.builders.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
@@ -26,13 +27,11 @@ import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 
 @PublishedApi
 @InternalEncodingApi
-internal val COMPATIBILITY: Base16 = Base16(
-    Base16.Configuration(
-        isLenient = true,
-        acceptLowercase = false,
-        encodeToLowercase = false,
-    )
-)
+internal val COMPATIBILITY: Base16 = Base16 {
+    isLenient = true
+    acceptLowercase = false
+    encodeToLowercase = false
+}
 
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase16ToArray(): ByteArray? {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -73,7 +73,7 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
     ): EncoderDecoder.Configuration(isLenient, paddingByte = null) {
 
         override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int = encodedSize / 2
-        override fun encodeOutSize(unEncodedSize: Int): Int = unEncodedSize * 2
+        override fun encodeOutSizeProtected(unEncodedSize: Int): Int = unEncodedSize * 2
 
         override fun toStringAddSettings(sb: StringBuilder) {
             with(sb) {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -17,7 +17,7 @@
 
 package io.matthewnelson.encoding.base16
 
-import io.matthewnelson.encoding.builders.Base16Builder
+import io.matthewnelson.encoding.builders.Base16ConfigBuilder
 import io.matthewnelson.encoding.core.*
 import io.matthewnelson.encoding.core.internal.EncodingTable
 import io.matthewnelson.encoding.core.internal.InternalEncodingApi
@@ -49,29 +49,29 @@ import kotlin.jvm.JvmSynthetic
  *     val decoded = encoded.decodeToArray(base16).decodeToString()
  *     assertEquals(text, decoded)
  *
- * @see [Base16Builder]
- * @see [Configuration]
+ * @see [Base16ConfigBuilder]
+ * @see [Config]
  * @see [CHARS]
  * @see [EncoderDecoder]
  * */
 @OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
-public class Base16(config: Configuration): EncoderDecoder(config) {
+public class Base16(config: Config): EncoderDecoder(config) {
 
     /**
      * Configuration for [Base16] encoding/decoding.
      *
-     * Use [Base16Builder] to create.
+     * Use [Base16ConfigBuilder] to create.
      *
-     * @see [Base16Builder]
-     * @see [EncoderDecoder.Configuration]
+     * @see [Base16ConfigBuilder]
+     * @see [EncoderDecoder.Config]
      * */
-    public class Configuration private constructor(
+    public class Config private constructor(
         isLenient: Boolean,
         @JvmField
         public val acceptLowercase: Boolean,
         @JvmField
         public val encodeToLowercase: Boolean,
-    ): EncoderDecoder.Configuration(isLenient, paddingByte = null) {
+    ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
         override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int = encodedSize / 2
         override fun encodeOutSizeProtected(unEncodedSize: Int): Int = unEncodedSize * 2
@@ -88,8 +88,8 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
 
         internal companion object {
             @JvmSynthetic
-            internal fun from(builder: Base16Builder): Configuration {
-                return Configuration(
+            internal fun from(builder: Base16ConfigBuilder): Config {
+                return Config(
                     isLenient = builder.isLenient,
                     acceptLowercase = builder.acceptLowercase,
                     encodeToLowercase = builder.encodeToLowercase,
@@ -115,7 +115,7 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
                 val b1 = TABLE[bits shr    4]
                 val b2 = TABLE[bits and 0x0f]
 
-                if ((config as Configuration).encodeToLowercase) {
+                if ((config as Config).encodeToLowercase) {
                     out.invoke(b1.lowercaseCharByte())
                     out.invoke(b2.lowercaseCharByte())
                 } else {
@@ -135,7 +135,7 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
 
             @Throws(EncodingException::class)
             override fun updateProtected(input: Byte) {
-                val char = if ((config as Configuration).acceptLowercase) {
+                val char = if ((config as Config).acceptLowercase) {
                     input.char.uppercaseChar()
                 } else {
                     input.char

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -73,7 +73,7 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
     ): EncoderDecoder.Configuration(isLenient, paddingByte = null) {
 
         override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int = encodedSize / 2
-        override fun encodeOutSize(unencodedSize: Int): Int = unencodedSize * 2
+        override fun encodeOutSize(unEncodedSize: Int): Int = unEncodedSize * 2
 
         override fun toStringAddSettings(sb: StringBuilder) {
             with(sb) {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -30,6 +30,7 @@ import kotlin.jvm.JvmField
 /**
  * Base16 (aka "hex") encoding/decoding in accordance with
  * RFC 4648 section 8.
+ *
  * https://www.ietf.org/rfc/rfc4648.html#section-8
  *
  * e.g.
@@ -58,13 +59,12 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
     /**
      * Configuration for [Base16] encoding/decoding.
      *
-     * @param [isLenient] See [EncoderDecoder.Configuration]
-     * @param [acceptLowercase] If true, will also accept lowercase
-     *   characters when decoding (against RFC 4648).
-     * @param [encodeToLowercase] If true, will output lowercase
-     *   characters instead of uppercase (against RFC 4648).
+     * Use [Base16Builder] to create.
+     *
+     * @see [Base16Builder]
+     * @see [EncoderDecoder.Configuration]
      * */
-    public class Configuration(
+    public class Configuration internal constructor(
         isLenient: Boolean,
         @JvmField
         public val acceptLowercase: Boolean,
@@ -87,6 +87,10 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
     }
 
     public companion object {
+
+        /**
+         * Base16 encoding characters.
+         * */
         public const val CHARS: String = "0123456789ABCDEF"
         private val TABLE = EncodingTable.from(CHARS)
     }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -26,6 +26,7 @@ import io.matthewnelson.encoding.core.util.char
 import io.matthewnelson.encoding.core.util.isSpaceOrNewLine
 import io.matthewnelson.encoding.core.util.lowercaseCharByte
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Base16 (aka "hex") encoding/decoding in accordance with
@@ -64,7 +65,7 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
      * @see [Base16Builder]
      * @see [EncoderDecoder.Configuration]
      * */
-    public class Configuration internal constructor(
+    public class Configuration private constructor(
         isLenient: Boolean,
         @JvmField
         public val acceptLowercase: Boolean,
@@ -82,6 +83,17 @@ public class Base16(config: Configuration): EncoderDecoder(config) {
                 appendLine()
                 append("    encodeToLowercase: ")
                 append(encodeToLowercase)
+            }
+        }
+
+        internal companion object {
+            @JvmSynthetic
+            internal fun from(builder: Base16Builder): Configuration {
+                return Configuration(
+                    isLenient = builder.isLenient,
+                    acceptLowercase = builder.acceptLowercase,
+                    encodeToLowercase = builder.encodeToLowercase,
+                )
             }
         }
     }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -19,6 +19,7 @@ import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.base16.Base16.Config
 import io.matthewnelson.encoding.core.EncodingException
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmOverloads
 
 /**
  * Creates a configured [Base16] encoder/decoder.
@@ -50,14 +51,18 @@ public fun Base16(
  * Creates a configured [Base16] encoder/decoder
  * using the default settings.
  *
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
  * @see [Base16ConfigBuilder]
  * */
-public fun Base16(): Base16 = Base16 {}
+@JvmOverloads
+public fun Base16(strict: Boolean = false): Base16 = Base16 { if (strict) strict() }
 
 
 /**
  * Builder for creating a [Base16.Config].
  *
+ * @see [strict]
  * @see [io.matthewnelson.encoding.builders.Base16]
  * */
 public class Base16ConfigBuilder {
@@ -99,6 +104,17 @@ public class Base16ConfigBuilder {
      * */
     @JvmField
     public var encodeToLowercase: Boolean = true
+
+    /**
+     * A shortcut for configuring things to be in strict
+     * adherence with RFC 4648.
+     * */
+    public fun strict(): Base16ConfigBuilder {
+        isLenient = false
+        acceptLowercase = false
+        encodeToLowercase = false
+        return this
+    }
 
     /**
      * Builds a [Base16.Config] for the provided settings.

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -33,7 +33,7 @@ public fun Base16(
 ): Base16 {
     val builder = Base16Builder(config)
     block.invoke(builder)
-    return builder.build()
+    return Base16(builder.build())
 }
 
 /**
@@ -82,20 +82,17 @@ public class Base16Builder {
     public var acceptLowercase: Boolean = true
 
     /**
-     * If true, will output lowercase characters instead of
-     * uppercase (against RFC 4648).
+     * If true, will output lowercase characters when
+     * encoding (against RFC 4648).
+     *
+     * If false, will output uppercase characters when
+     * encoding.
      * */
     @JvmField
     public var encodeToLowercase: Boolean = true
 
     /**
-     * Builds a [Base16] encoder/decoder for the given settings.
+     * Builds a [Base16.Configuration] for the given settings.
      * */
-    public fun build(): Base16 {
-        return Base16(Configuration(
-            isLenient = isLenient,
-            acceptLowercase = acceptLowercase,
-            encodeToLowercase = encodeToLowercase,
-        ))
-    }
+    public fun build(): Configuration = Configuration.from(this)
 }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -17,38 +17,81 @@ package io.matthewnelson.encoding.builders
 
 import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.base16.Base16.Configuration
+import io.matthewnelson.encoding.core.EncoderDecoder
+import io.matthewnelson.encoding.core.EncodingException
 import kotlin.jvm.JvmField
 
 /**
- * Builder for [Base16]
+ * Builds a [Base16] encoder/decoder.
+ *
+ * @param [config] inherit settings from.
+ * @see [Base16Builder]
  * */
-public fun Base16(block: Base16Builder.() -> Unit): Base16 {
-    val builder = Base16Builder()
+public fun Base16(
+    config: Configuration?,
+    block: Base16Builder.() -> Unit
+): Base16 {
+    val builder = Base16Builder(config)
     block.invoke(builder)
     return builder.build()
 }
 
-public class Base16Builder internal constructor() {
+/**
+ * Builds a [Base16] encoder/decoder.
+ *
+ * @see [Base16Builder]
+ * */
+public fun Base16(
+    block: Base16Builder.() -> Unit
+): Base16 {
+    return Base16(config = null, block)
+}
+
+/**
+ * Builder for configuring and then creating
+ * a [Base16] encoder/decoder.
+ * */
+public class Base16Builder {
+
+    public constructor()
+    public constructor(config: Configuration?): this() {
+        if (config == null) return
+        isLenient = config.isLenient
+        acceptLowercase = config.acceptLowercase
+        encodeToLowercase = config.encodeToLowercase
+    }
 
     /**
-     * See [Configuration.isLenient]
+     * If true, spaces and new lines ('\n', '\r', ' ', '\t')
+     * will be skipped over when decoding.
+     *
+     * If false, an [EncodingException] will be thrown if
+     * those characters are encountered when decoding.
      * */
     @JvmField
-    public var isLenient: Boolean = false
+    public var isLenient: Boolean = true
 
     /**
-     * See [Configuration.acceptLowercase]
+     * If true, will accept lowercase **AND** uppercase
+     * characters when decoding (against RFC 4648).
+     *
+     * If false, an [EncodingException] will be thrown if
+     * lowercase characters are encountered when decoding.
      * */
     @JvmField
-    public var acceptLowercase: Boolean = false
+    public var acceptLowercase: Boolean = true
 
     /**
-     * See [Configuration.encodeToLowercase]
+     * If true, will output lowercase characters instead of
+     * uppercase (against RFC 4648).
      * */
     @JvmField
-    public var encodeToLowercase: Boolean = false
+    public var encodeToLowercase: Boolean = true
 
-    internal fun build(): Base16 {
+    /**
+     * Builds a [Base16] encoder/decoder for the given settings.
+     * */
+    public fun build(): Base16 {
         return Base16(Configuration(
             isLenient = isLenient,
             acceptLowercase = acceptLowercase,

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -22,7 +22,7 @@ import io.matthewnelson.encoding.core.EncodingException
 import kotlin.jvm.JvmField
 
 /**
- * Builds a [Base16] encoder/decoder.
+ * Creates a configured [Base16] encoder/decoder.
  *
  * @param [config] inherit settings from.
  * @see [Base16Builder]
@@ -37,7 +37,7 @@ public fun Base16(
 }
 
 /**
- * Builds a [Base16] encoder/decoder.
+ * Creates a configured [Base16] encoder/decoder.
  *
  * @see [Base16Builder]
  * */
@@ -48,8 +48,9 @@ public fun Base16(
 }
 
 /**
- * Builder for configuring and then creating
- * a [Base16] encoder/decoder.
+ * Builder for creating a [Base16.Configuration].
+ *
+ * @see [io.matthewnelson.encoding.builders.Base16]
  * */
 public class Base16Builder {
 
@@ -92,7 +93,7 @@ public class Base16Builder {
     public var encodeToLowercase: Boolean = true
 
     /**
-     * Builds a [Base16.Configuration] for the given settings.
+     * Builds a [Base16.Configuration] for the provided settings.
      * */
     public fun build(): Configuration = Configuration.from(this)
 }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -19,6 +19,9 @@ import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.base16.Base16.Configuration
 import kotlin.jvm.JvmField
 
+/**
+ * Builder for [Base16]
+ * */
 public fun Base16(block: Base16Builder.() -> Unit): Base16 {
     val builder = Base16Builder()
     block.invoke(builder)

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -16,8 +16,7 @@
 package io.matthewnelson.encoding.builders
 
 import io.matthewnelson.encoding.base16.Base16
-import io.matthewnelson.encoding.base16.Base16.Configuration
-import io.matthewnelson.encoding.core.EncoderDecoder
+import io.matthewnelson.encoding.base16.Base16.Config
 import io.matthewnelson.encoding.core.EncodingException
 import kotlin.jvm.JvmField
 
@@ -25,13 +24,13 @@ import kotlin.jvm.JvmField
  * Creates a configured [Base16] encoder/decoder.
  *
  * @param [config] inherit settings from.
- * @see [Base16Builder]
+ * @see [Base16ConfigBuilder]
  * */
 public fun Base16(
-    config: Configuration?,
-    block: Base16Builder.() -> Unit
+    config: Config?,
+    block: Base16ConfigBuilder.() -> Unit
 ): Base16 {
-    val builder = Base16Builder(config)
+    val builder = Base16ConfigBuilder(config)
     block.invoke(builder)
     return Base16(builder.build())
 }
@@ -39,23 +38,32 @@ public fun Base16(
 /**
  * Creates a configured [Base16] encoder/decoder.
  *
- * @see [Base16Builder]
+ * @see [Base16ConfigBuilder]
  * */
 public fun Base16(
-    block: Base16Builder.() -> Unit
+    block: Base16ConfigBuilder.() -> Unit
 ): Base16 {
     return Base16(config = null, block)
 }
 
 /**
- * Builder for creating a [Base16.Configuration].
+ * Creates a configured [Base16] encoder/decoder
+ * using the default settings.
+ *
+ * @see [Base16ConfigBuilder]
+ * */
+public fun Base16(): Base16 = Base16 {}
+
+
+/**
+ * Builder for creating a [Base16.Config].
  *
  * @see [io.matthewnelson.encoding.builders.Base16]
  * */
-public class Base16Builder {
+public class Base16ConfigBuilder {
 
     public constructor()
-    public constructor(config: Configuration?): this() {
+    public constructor(config: Config?): this() {
         if (config == null) return
         isLenient = config.isLenient
         acceptLowercase = config.acceptLowercase
@@ -93,7 +101,7 @@ public class Base16Builder {
     public var encodeToLowercase: Boolean = true
 
     /**
-     * Builds a [Base16.Configuration] for the provided settings.
+     * Builds a [Base16.Config] for the provided settings.
      * */
-    public fun build(): Configuration = Configuration.from(this)
+    public fun build(): Config = Config.from(this)
 }

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -49,3 +49,104 @@ public final class io/matthewnelson/component/encoding/base32/Base32Kt {
 	public static synthetic fun encodeBase32ToCharArray$default ([BLio/matthewnelson/component/encoding/base32/Base32;ILjava/lang/Object;)[C
 }
 
+public abstract class io/matthewnelson/encoding/base32/Base32 : io/matthewnelson/encoding/core/EncoderDecoder {
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Crockford : io/matthewnelson/encoding/base32/Base32 {
+	public static final field CHARS Ljava/lang/String;
+	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Crockford$Companion;
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;)V
+	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
+	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Crockford$Companion {
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Crockford$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+	public final field acceptLowercase Z
+	public final field hyphenInterval S
+	public synthetic fun <init> (ZZSLjava/lang/Byte;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+	public final fun getCheckSymbol ()Ljava/lang/Character;
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Default : io/matthewnelson/encoding/base32/Base32 {
+	public static final field CHARS Ljava/lang/String;
+	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Default$Companion;
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;)V
+	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
+	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Default$Companion {
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Default$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+	public final field acceptLowercase Z
+	public final field encodeToLowercase Z
+	public final field padEncoded Z
+	public synthetic fun <init> (ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelson/encoding/base32/Base32 {
+	public static final field CHARS Ljava/lang/String;
+	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Hex$Companion;
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;)V
+	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
+	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Hex$Companion {
+}
+
+public final class io/matthewnelson/encoding/base32/Base32$Hex$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+	public final field acceptLowercase Z
+	public final field encodeToLowercase Z
+	public final field padEncoded Z
+	public synthetic fun <init> (ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+}
+
+public final class io/matthewnelson/encoding/builders/Base32CrockfordBuilder {
+	public field acceptLowercase Z
+	public field hyphenInterval S
+	public field isLenient Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;
+	public final fun getCheckSymbol ()Ljava/lang/Character;
+	public final fun setCheckSymbol (Ljava/lang/Character;)Lio/matthewnelson/encoding/builders/Base32CrockfordBuilder;
+}
+
+public final class io/matthewnelson/encoding/builders/Base32DefaultBuilder {
+	public field acceptLowercase Z
+	public field encodeToLowercase Z
+	public field isLenient Z
+	public field padEncoded Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;
+}
+
+public final class io/matthewnelson/encoding/builders/Base32HexBuilder {
+	public field acceptLowercase Z
+	public field encodeToLowercase Z
+	public field isLenient Z
+	public field padEncoded Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;
+}
+
+public final class io/matthewnelson/encoding/builders/Base32Kt {
+	public static final fun Base32Crockford (Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Crockford (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Default (Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Default (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Hex (Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static final fun Base32Hex (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
+}
+

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -50,13 +50,13 @@ public final class io/matthewnelson/component/encoding/base32/Base32Kt {
 }
 
 public abstract class io/matthewnelson/encoding/base32/Base32 : io/matthewnelson/encoding/core/EncoderDecoder {
-	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Crockford : io/matthewnelson/encoding/base32/Base32 {
 	public static final field CHARS Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Crockford$Companion;
-	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;)V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
 	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
@@ -64,7 +64,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Crockford : io/matthe
 public final class io/matthewnelson/encoding/base32/Base32$Crockford$Companion {
 }
 
-public final class io/matthewnelson/encoding/base32/Base32$Crockford$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+public final class io/matthewnelson/encoding/base32/Base32$Crockford$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field acceptLowercase Z
 	public final field checkByte Ljava/lang/Byte;
 	public final field hyphenInterval S
@@ -76,7 +76,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Crockford$Configurati
 public final class io/matthewnelson/encoding/base32/Base32$Default : io/matthewnelson/encoding/base32/Base32 {
 	public static final field CHARS Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Default$Companion;
-	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;)V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
 	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
@@ -84,7 +84,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Default : io/matthewn
 public final class io/matthewnelson/encoding/base32/Base32$Default$Companion {
 }
 
-public final class io/matthewnelson/encoding/base32/Base32$Default$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+public final class io/matthewnelson/encoding/base32/Base32$Default$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
@@ -95,7 +95,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Default$Configuration
 public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelson/encoding/base32/Base32 {
 	public static final field CHARS Ljava/lang/String;
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Hex$Companion;
-	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;)V
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
 	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
@@ -103,7 +103,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelso
 public final class io/matthewnelson/encoding/base32/Base32$Hex$Companion {
 }
 
-public final class io/matthewnelson/encoding/base32/Base32$Hex$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+public final class io/matthewnelson/encoding/base32/Base32$Hex$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
@@ -111,44 +111,47 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex$Configuration : i
 	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
 
-public final class io/matthewnelson/encoding/builders/Base32CrockfordBuilder {
+public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder {
 	public field acceptLowercase Z
 	public field hyphenInterval S
 	public field isLenient Z
 	public fun <init> ()V
-	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;)V
-	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;
 	public final fun checkByte ()Ljava/lang/Byte;
-	public final fun checkByte (Ljava/lang/Character;)Lio/matthewnelson/encoding/builders/Base32CrockfordBuilder;
+	public final fun checkByte (Ljava/lang/Character;)Lio/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder;
 	public final fun checkSymbol ()Ljava/lang/Character;
 }
 
-public final class io/matthewnelson/encoding/builders/Base32DefaultBuilder {
+public final class io/matthewnelson/encoding/builders/Base32DefaultConfigBuilder {
 	public field acceptLowercase Z
 	public field encodeToLowercase Z
 	public field isLenient Z
 	public field padEncoded Z
 	public fun <init> ()V
-	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;)V
-	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Default$Config;
 }
 
-public final class io/matthewnelson/encoding/builders/Base32HexBuilder {
+public final class io/matthewnelson/encoding/builders/Base32HexConfigBuilder {
 	public field acceptLowercase Z
 	public field encodeToLowercase Z
 	public field isLenient Z
 	public field padEncoded Z
 	public fun <init> ()V
-	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;)V
-	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;
+	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Hex$Config;
 }
 
 public final class io/matthewnelson/encoding/builders/Base32Kt {
-	public static final fun Base32Crockford (Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Crockford ()Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Crockford (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
 	public static final fun Base32Crockford (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
-	public static final fun Base32Default (Lio/matthewnelson/encoding/base32/Base32$Default$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Default ()Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Default (Lio/matthewnelson/encoding/base32/Base32$Default$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
 	public static final fun Base32Default (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
-	public static final fun Base32Hex (Lio/matthewnelson/encoding/base32/Base32$Hex$Configuration;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static final fun Base32Hex ()Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static final fun Base32Hex (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
 	public static final fun Base32Hex (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
 }
 

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -66,10 +66,11 @@ public final class io/matthewnelson/encoding/base32/Base32$Crockford$Companion {
 
 public final class io/matthewnelson/encoding/base32/Base32$Crockford$Configuration : io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
 	public final field acceptLowercase Z
+	public final field checkByte Ljava/lang/Byte;
 	public final field hyphenInterval S
 	public synthetic fun <init> (ZZSLjava/lang/Byte;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun checkSymbol ()Ljava/lang/Character;
 	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
-	public final fun getCheckSymbol ()Ljava/lang/Character;
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Default : io/matthewnelson/encoding/base32/Base32 {
@@ -117,8 +118,9 @@ public final class io/matthewnelson/encoding/builders/Base32CrockfordBuilder {
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;)V
 	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Crockford$Configuration;
-	public final fun getCheckSymbol ()Ljava/lang/Character;
-	public final fun setCheckSymbol (Ljava/lang/Character;)Lio/matthewnelson/encoding/builders/Base32CrockfordBuilder;
+	public final fun checkByte ()Ljava/lang/Byte;
+	public final fun checkByte (Ljava/lang/Character;)Lio/matthewnelson/encoding/builders/Base32CrockfordBuilder;
+	public final fun checkSymbol ()Ljava/lang/Character;
 }
 
 public final class io/matthewnelson/encoding/builders/Base32DefaultBuilder {

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -67,8 +67,9 @@ public final class io/matthewnelson/encoding/base32/Base32$Crockford$Companion {
 public final class io/matthewnelson/encoding/base32/Base32$Crockford$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field acceptLowercase Z
 	public final field checkByte Ljava/lang/Byte;
+	public final field encodeToLowercase Z
 	public final field hyphenInterval S
-	public synthetic fun <init> (ZZSLjava/lang/Byte;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZZSLjava/lang/Byte;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun checkSymbol ()Ljava/lang/Character;
 	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
@@ -113,6 +114,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex$Config : io/matth
 
 public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder {
 	public field acceptLowercase Z
+	public field encodeToLowercase Z
 	public field hyphenInterval S
 	public field isLenient Z
 	public fun <init> ()V

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -123,6 +123,7 @@ public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuild
 	public final fun checkByte ()Ljava/lang/Byte;
 	public final fun checkByte (Ljava/lang/Character;)Lio/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder;
 	public final fun checkSymbol ()Ljava/lang/Character;
+	public final fun strict ()Lio/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder;
 }
 
 public final class io/matthewnelson/encoding/builders/Base32DefaultConfigBuilder {
@@ -133,6 +134,7 @@ public final class io/matthewnelson/encoding/builders/Base32DefaultConfigBuilder
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Config;)V
 	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Default$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/builders/Base32DefaultConfigBuilder;
 }
 
 public final class io/matthewnelson/encoding/builders/Base32HexConfigBuilder {
@@ -143,17 +145,24 @@ public final class io/matthewnelson/encoding/builders/Base32HexConfigBuilder {
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;)V
 	public final fun build ()Lio/matthewnelson/encoding/base32/Base32$Hex$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/builders/Base32HexConfigBuilder;
 }
 
 public final class io/matthewnelson/encoding/builders/Base32Kt {
 	public static final fun Base32Crockford ()Lio/matthewnelson/encoding/base32/Base32$Crockford;
 	public static final fun Base32Crockford (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
 	public static final fun Base32Crockford (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static final fun Base32Crockford (Z)Lio/matthewnelson/encoding/base32/Base32$Crockford;
+	public static synthetic fun Base32Crockford$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base32/Base32$Crockford;
 	public static final fun Base32Default ()Lio/matthewnelson/encoding/base32/Base32$Default;
 	public static final fun Base32Default (Lio/matthewnelson/encoding/base32/Base32$Default$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
 	public static final fun Base32Default (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static final fun Base32Default (Z)Lio/matthewnelson/encoding/base32/Base32$Default;
+	public static synthetic fun Base32Default$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base32/Base32$Default;
 	public static final fun Base32Hex ()Lio/matthewnelson/encoding/base32/Base32$Hex;
 	public static final fun Base32Hex (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
 	public static final fun Base32Hex (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static final fun Base32Hex (Z)Lio/matthewnelson/encoding/base32/Base32$Hex;
+	public static synthetic fun Base32Hex$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base32/Base32$Hex;
 }
 

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
@@ -63,7 +63,7 @@ public sealed class Base32 {
         }
 
         public companion object {
-            public const val CHARS: String = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+            public const val CHARS: String = io.matthewnelson.encoding.base32.Base32.Crockford.CHARS
         }
 
         override val encodingTable: ByteArray get() = CROCKFORD_TABLE
@@ -76,7 +76,7 @@ public sealed class Base32 {
      * https://www.ietf.org/rfc/rfc4648.html#section-6
      * */
     public object Default: Base32() {
-        public const val CHARS: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+        public const val CHARS: String = io.matthewnelson.encoding.base32.Base32.Default.CHARS
         override val encodingTable: ByteArray get() = DEFAULT_TABLE
     }
 
@@ -85,7 +85,7 @@ public sealed class Base32 {
      * https://www.ietf.org/rfc/rfc4648.html#section-7
      * */
     public object Hex: Base32() {
-        public const val CHARS: String = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+        public const val CHARS: String = io.matthewnelson.encoding.base32.Base32.Hex.CHARS
         override val encodingTable: ByteArray get() = HEX_TABLE
     }
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("MemberVisibilityCanBePrivate", "RemoveRedundantQualifierName", "SpellCheckingInspection")
+
+package io.matthewnelson.encoding.base32
+
+import io.matthewnelson.encoding.builders.*
+import io.matthewnelson.encoding.core.*
+import io.matthewnelson.encoding.core.internal.EncodingTable
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+import io.matthewnelson.encoding.core.util.DecoderInput
+import io.matthewnelson.encoding.core.util.byte
+import io.matthewnelson.encoding.core.util.char
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Base32 encoding/decoding.
+ *
+ * @see [Crockford]
+ * @see [Default]
+ * @see [Hex]
+ * */
+@OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
+public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder(config) {
+
+    /**
+     * Base32 Crockford encoding/decoding in accordance with
+     * https://www.crockford.com/base32.html
+     *
+     * e.g.
+     *
+     *     val base32Crockford = Base32Crockford {
+     *         isLenient = true
+     *         acceptLowercase = true
+     *         hyphenInterval = 5
+     *         setCheckSymbol('*')
+     *     }
+     *
+     *     val text = "Hello World!"
+     *     val bytes = text.encodeToByteArray()
+     *     val encoded = bytes.encodeToString(base32Crockford)
+     *     println(encoded) // 91JPR-V3F41-BPYWK-CCGGG*
+     *     val decoded = encoded.decodeToArray(base32Crockford).decodeToString()
+     *     assertEquals(text, decoded)
+     *
+     * @see [Base32Crockford]
+     * @see [Configuration]
+     * @see [CHARS]
+     * @see [EncoderDecoder]
+     * */
+    public class Crockford(config: Crockford.Configuration): Base32(config) {
+
+        /**
+         * Configuration for [Base32.Crockford] encoding/decoding.
+         *
+         * Use [Base32CrockfordBuilder] to create.
+         *
+         * @see [Base32CrockfordBuilder]
+         * @see [EncoderDecoder.Configuration]
+         * */
+        public class Configuration private constructor(
+            isLenient: Boolean,
+            @JvmField
+            public val acceptLowercase: Boolean,
+            @JvmField
+            public val hyphenInterval: Short,
+            internal val checkByte: Byte?,
+        ): EncoderDecoder.Configuration(isLenient, paddingByte = null) {
+
+            public val checkSymbol: Char? get() = checkByte?.char
+
+            @Throws(EncodingException::class)
+            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
+                // TODO
+                throw EncodingException("Not yet implemented")
+            }
+
+            override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
+                var outSize = encodedOutSize(unEncodedSize, willBePadded = false)
+
+                if (hyphenInterval > 0) {
+                    val interval = hyphenInterval.toInt()
+                    val size = outSize
+                    var count = 0
+                    var index = 0
+                    while (index++ < size) {
+                        if (count++ != interval) continue
+                        outSize++
+                        count = 0
+                    }
+                }
+
+                // checkByte will be appended if present
+                if (checkByte != null) {
+                    outSize++
+                }
+
+                return outSize
+            }
+
+            override fun toStringAddSettings(sb: StringBuilder) {
+                with(sb) {
+                    append("    acceptLowercase: ")
+                    append(acceptLowercase)
+                    appendLine()
+                    append("    hyphenInterval: ")
+                    append(hyphenInterval)
+                    appendLine()
+                    append("    checkSymbol: ")
+                    append(checkSymbol)
+                }
+            }
+
+            internal companion object {
+
+                @JvmSynthetic
+                internal fun from(builder: Base32CrockfordBuilder): Configuration {
+                    return Configuration(
+                        isLenient = builder.isLenient,
+                        acceptLowercase = builder.acceptLowercase,
+                        hyphenInterval = builder.hyphenInterval,
+                        checkByte = builder.checkByte
+                    )
+                }
+            }
+        }
+
+        public companion object {
+
+            /**
+             * Base32 Crockford encoding characters.
+             * */
+            public const val CHARS: String = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+            private val TABLE = EncodingTable.from(CHARS)
+        }
+
+        override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
+            return object : Decoder.Feed() {
+
+                @Throws(EncodingException::class)
+                override fun updateProtected(input: Byte) {
+                    // TODO
+                    throw EncodingException("Not yet implemented")
+                }
+
+                @Throws(EncodingException::class)
+                override fun doFinalProtected() {
+                    // TODO
+                    throw EncodingException("Not yet implemented")
+                }
+
+            }
+        }
+
+        override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
+            return object : Encoder.Feed() {
+
+                override fun updateProtected(input: Byte) {
+                    // TODO
+                }
+
+                override fun doFinalProtected() {
+                    // TODO
+                }
+            }
+        }
+
+        override fun name(): String = "Base32.Crockford"
+    }
+
+    /**
+     * Base 32 Default encoding/decoding in accordance with
+     * RFC 4648 section 6.
+     *
+     * https://www.ietf.org/rfc/rfc4648.html#section-6
+     *
+     * e.g.
+     *
+     *     val base32Default = Base32Default {
+     *         isLenient = true
+     *         acceptLowercase = true
+     *         encodeToLowercase = false
+     *         padEncoded = true
+     *     }
+     *
+     *     val text = "Hello World!"
+     *     val bytes = text.encodeToByteArray()
+     *     val encoded = bytes.encodeToString(base32Default)
+     *     println(encoded) // JBSWY3DPEBLW64TMMQQQ====
+     *     val decoded = encoded.decodeToArray(base32Default).decodeToString()
+     *     assertEquals(text, decoded)
+     *
+     * @see [Base32Default]
+     * @see [Configuration]
+     * @see [CHARS]
+     * @see [EncoderDecoder]
+     * */
+    public class Default(config: Default.Configuration): Base32(config) {
+
+        /**
+         * Configuration for [Base32.Default] encoding/decoding.
+         *
+         * Use [Base32DefaultBuilder] to create.
+         *
+         * @see [Base32DefaultBuilder]
+         * @see [EncoderDecoder.Configuration]
+         * */
+        public class Configuration private constructor(
+            isLenient: Boolean,
+            @JvmField
+            public val acceptLowercase: Boolean,
+            @JvmField
+            public val encodeToLowercase: Boolean,
+            @JvmField
+            public val padEncoded: Boolean,
+        ): EncoderDecoder.Configuration(isLenient, paddingByte = '='.byte) {
+
+            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
+                // TODO
+                throw EncodingException("Not yet implemented")
+            }
+
+            override fun encodeOutSizeProtected(unEncodedSize: Int): Int = encodedOutSize(unEncodedSize, padEncoded)
+
+            override fun toStringAddSettings(sb: StringBuilder) {
+                with(sb) {
+                    append("    acceptLowercase: ")
+                    append(acceptLowercase)
+                    appendLine()
+                    append("    encodeToLowercase: ")
+                    append(encodeToLowercase)
+                    appendLine()
+                    append("    padEncoded: ")
+                    append(padEncoded)
+                }
+            }
+
+            internal companion object {
+
+                @JvmSynthetic
+                internal fun from(builder: Base32DefaultBuilder): Configuration {
+                    return Configuration(
+                        isLenient = builder.isLenient,
+                        acceptLowercase = builder.acceptLowercase,
+                        encodeToLowercase = builder.encodeToLowercase,
+                        padEncoded = builder.padEncoded,
+                    )
+                }
+            }
+        }
+
+        public companion object {
+
+            /**
+             * Base32 Default encoding characters.
+             * */
+            public const val CHARS: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+            private val TABLE = EncodingTable.from(CHARS)
+        }
+
+        override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
+            return object : Decoder.Feed() {
+
+                @Throws(EncodingException::class)
+                override fun updateProtected(input: Byte) {
+                    // TODO
+                    throw EncodingException("Not yet implemented")
+                }
+
+                @Throws(EncodingException::class)
+                override fun doFinalProtected() {
+                    // TODO
+                    throw EncodingException("Not yet implemented")
+                }
+            }
+        }
+
+        override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
+            return object : Encoder.Feed() {
+
+                override fun updateProtected(input: Byte) {
+                    // TODO
+                }
+
+                override fun doFinalProtected() {
+                    // TODO
+                }
+            }
+        }
+
+        override fun name(): String = "Base32.Default"
+    }
+
+    /**
+     * Base 32 Default encoding/decoding in accordance with
+     * RFC 4648 section 7.
+     *
+     * https://www.ietf.org/rfc/rfc4648.html#section-7
+     *
+     * e.g.
+     *
+     *     val base32Hex = Base32Hex {
+     *         isLenient = true
+     *         acceptLowercase = true
+     *         encodeToLowercase = false
+     *         padEncoded = true
+     *     }
+     *
+     *     val text = "Hello World!"
+     *     val bytes = text.encodeToByteArray()
+     *     val encoded = bytes.encodeToString(base32Hex)
+     *     println(encoded) // 91IMOR3F41BMUSJCCGGG====
+     *     val decoded = encoded.decodeToArray(base32Hex).decodeToString()
+     *     assertEquals(text, decoded)
+     *
+     * @see [Base32Hex]
+     * @see [CHARS]
+     * @see [EncoderDecoder]
+     * */
+    public class Hex(config: Hex.Configuration): Base32(config) {
+
+        /**
+         * Configuration for [Base32.Hex] encoding/decoding.
+         *
+         * Use [Base32HexBuilder] to create.
+         *
+         * @see [Base32HexBuilder]
+         * @see [EncoderDecoder.Configuration]
+         * */
+        public class Configuration private constructor(
+            isLenient: Boolean,
+            @JvmField
+            public val acceptLowercase: Boolean,
+            @JvmField
+            public val encodeToLowercase: Boolean,
+            @JvmField
+            public val padEncoded: Boolean,
+        ): EncoderDecoder.Configuration(isLenient, paddingByte = '='.byte) {
+
+            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
+                // TODO
+                throw EncodingException("Not yet implemented")
+            }
+
+            override fun encodeOutSizeProtected(unEncodedSize: Int): Int = encodedOutSize(unEncodedSize, padEncoded)
+
+            override fun toStringAddSettings(sb: StringBuilder) {
+                with(sb) {
+                    append("    acceptLowercase: ")
+                    append(acceptLowercase)
+                    appendLine()
+                    append("    encodeToLowercase: ")
+                    append(encodeToLowercase)
+                    appendLine()
+                    append("    padEncoded: ")
+                    append(padEncoded)
+                }
+            }
+
+            internal companion object {
+
+                @JvmSynthetic
+                internal fun from(builder: Base32HexBuilder): Configuration {
+                    return Configuration(
+                        isLenient = builder.isLenient,
+                        acceptLowercase = builder.acceptLowercase,
+                        encodeToLowercase = builder.encodeToLowercase,
+                        padEncoded = builder.padEncoded,
+                    )
+                }
+            }
+        }
+
+        public companion object {
+
+            /**
+             * Base32 Hex encoding characters.
+             * */
+            public const val CHARS: String = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+            private val TABLE = EncodingTable.from(CHARS)
+        }
+
+        override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
+            return object : Decoder.Feed() {
+
+                @Throws(EncodingException::class)
+                override fun updateProtected(input: Byte) {
+                    // TODO
+                    throw EncodingException("Not yet implemented")
+                }
+
+                @Throws(EncodingException::class)
+                override fun doFinalProtected() {
+                    // TODO
+                    throw EncodingException("Not yet implemented")
+                }
+            }
+        }
+
+        override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
+            return object : Encoder.Feed() {
+
+                override fun updateProtected(input: Byte) {
+                    // TODO
+                }
+
+                override fun doFinalProtected() {
+                    // TODO
+                }
+            }
+        }
+
+        override fun name(): String = "Base32.Hex"
+    }
+
+    private companion object {
+
+        @JvmStatic
+        private fun encodedOutSize(
+            unEncodedSize: Int,
+            willBePadded: Boolean,
+        ): Int {
+            var outSize = (unEncodedSize + 4) / 5 * 8
+            if (willBePadded) return outSize
+
+            when (unEncodedSize - (unEncodedSize - unEncodedSize % 5)) {
+                0 -> { /* no-op */ }
+                1 -> outSize -= 6
+                2 -> outSize -= 4
+                3 -> outSize -= 3
+                4 -> outSize -= 1
+            }
+
+            return outSize
+        }
+    }
+}

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -25,6 +25,7 @@ import io.matthewnelson.encoding.core.util.DecoderInput
 import io.matthewnelson.encoding.core.util.byte
 import io.matthewnelson.encoding.core.util.char
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -48,7 +49,7 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
      *         isLenient = true
      *         acceptLowercase = true
      *         hyphenInterval = 5
-     *         setCheckSymbol('*')
+     *         setCheckByte(checkSymbol = '*')
      *     }
      *
      *     val text = "Hello World!"
@@ -79,9 +80,11 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             public val acceptLowercase: Boolean,
             @JvmField
             public val hyphenInterval: Short,
-            internal val checkByte: Byte?,
+            @JvmField
+            public val checkByte: Byte?,
         ): EncoderDecoder.Configuration(isLenient, paddingByte = null) {
 
+            @get:JvmName("checkSymbol")
             public val checkSymbol: Char? get() = checkByte?.char
 
             @Throws(EncodingException::class)
@@ -92,7 +95,9 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
                     // Check last character
                     val actual = input[encodedSize - 1]
                     if (actual != checkByte.char) {
-                        throw EncodingException("checkSymbol[$actual] for encoded did not match expected[$checkSymbol]")
+                        throw EncodingException(
+                            "checkSymbol[$actual] for encoded did not match expected[${checkByte.char}]"
+                        )
                     } else {
                         outSize--
                     }
@@ -133,7 +138,7 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
                     append(hyphenInterval)
                     appendLine()
                     append("    checkSymbol: ")
-                    append(checkSymbol)
+                    append(checkByte?.char)
                 }
             }
 

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -48,6 +48,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *     val base32Crockford = Base32Crockford {
      *         isLenient = true
      *         acceptLowercase = true
+     *         encodeToLowercase = false
      *         hyphenInterval = 5
      *         checkByte(checkSymbol = '~')
      *     }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -86,8 +86,19 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
 
             @Throws(EncodingException::class)
             override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
-                // TODO
-                throw EncodingException("Not yet implemented")
+                var outSize = encodedSize
+
+                if (checkByte != null) {
+                    // Check last character
+                    val actual = input[encodedSize - 1]
+                    if (actual != checkByte.char) {
+                        throw EncodingException("checkSymbol[$actual] for encoded did not match expected[$checkSymbol]")
+                    } else {
+                        outSize--
+                    }
+                }
+
+                return decodeOutMaxSize(outSize)
             }
 
             override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
@@ -231,11 +242,12 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
         ): EncoderDecoder.Configuration(isLenient, paddingByte = '='.byte) {
 
             override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
-                // TODO
-                throw EncodingException("Not yet implemented")
+                return decodeOutMaxSize(encodedSize)
             }
 
-            override fun encodeOutSizeProtected(unEncodedSize: Int): Int = encodedOutSize(unEncodedSize, padEncoded)
+            override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
+                return encodedOutSize(unEncodedSize, padEncoded)
+            }
 
             override fun toStringAddSettings(sb: StringBuilder) {
                 with(sb) {
@@ -353,11 +365,12 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
         ): EncoderDecoder.Configuration(isLenient, paddingByte = '='.byte) {
 
             override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
-                // TODO
-                throw EncodingException("Not yet implemented")
+                return decodeOutMaxSize(encodedSize)
             }
 
-            override fun encodeOutSizeProtected(unEncodedSize: Int): Int = encodedOutSize(unEncodedSize, padEncoded)
+            override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
+                return encodedOutSize(unEncodedSize, padEncoded)
+            }
 
             override fun toStringAddSettings(sb: StringBuilder) {
                 with(sb) {
@@ -429,6 +442,9 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
     }
 
     private companion object {
+
+        @JvmStatic
+        private fun decodeOutMaxSize(encodedSize: Int): Int = (encodedSize * 5L / 8L).toInt()
 
         @JvmStatic
         private fun encodedOutSize(

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -37,7 +37,7 @@ import kotlin.jvm.JvmSynthetic
  * @see [Hex]
  * */
 @OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
-public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder(config) {
+public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config) {
 
     /**
      * Base32 Crockford encoding/decoding in accordance with
@@ -60,21 +60,21 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
      *     assertEquals(text, decoded)
      *
      * @see [Base32Crockford]
-     * @see [Configuration]
+     * @see [Crockford.Config]
      * @see [CHARS]
      * @see [EncoderDecoder]
      * */
-    public class Crockford(config: Crockford.Configuration): Base32(config) {
+    public class Crockford(config: Crockford.Config): Base32(config) {
 
         /**
          * Configuration for [Base32.Crockford] encoding/decoding.
          *
-         * Use [Base32CrockfordBuilder] to create.
+         * Use [Base32CrockfordConfigBuilder] to create.
          *
-         * @see [Base32CrockfordBuilder]
-         * @see [EncoderDecoder.Configuration]
+         * @see [Base32CrockfordConfigBuilder]
+         * @see [EncoderDecoder.Config]
          * */
-        public class Configuration private constructor(
+        public class Config private constructor(
             isLenient: Boolean,
             @JvmField
             public val acceptLowercase: Boolean,
@@ -82,7 +82,7 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             public val hyphenInterval: Short,
             @JvmField
             public val checkByte: Byte?,
-        ): EncoderDecoder.Configuration(isLenient, paddingByte = null) {
+        ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
             @get:JvmName("checkSymbol")
             public val checkSymbol: Char? get() = checkByte?.char
@@ -109,6 +109,7 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
                 var outSize = encodedOutSize(unEncodedSize, willBePadded = false)
 
+                // TODO: Don't loop here... use maths
                 if (hyphenInterval > 0) {
                     val interval = hyphenInterval.toInt()
                     val size = outSize
@@ -145,8 +146,8 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             internal companion object {
 
                 @JvmSynthetic
-                internal fun from(builder: Base32CrockfordBuilder): Configuration {
-                    return Configuration(
+                internal fun from(builder: Base32CrockfordConfigBuilder): Config {
+                    return Config(
                         isLenient = builder.isLenient,
                         acceptLowercase = builder.acceptLowercase,
                         hyphenInterval = builder.hyphenInterval,
@@ -222,21 +223,21 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
      *     assertEquals(text, decoded)
      *
      * @see [Base32Default]
-     * @see [Configuration]
+     * @see [Default.Config]
      * @see [CHARS]
      * @see [EncoderDecoder]
      * */
-    public class Default(config: Default.Configuration): Base32(config) {
+    public class Default(config: Default.Config): Base32(config) {
 
         /**
          * Configuration for [Base32.Default] encoding/decoding.
          *
-         * Use [Base32DefaultBuilder] to create.
+         * Use [Base32DefaultConfigBuilder] to create.
          *
-         * @see [Base32DefaultBuilder]
-         * @see [EncoderDecoder.Configuration]
+         * @see [Base32DefaultConfigBuilder]
+         * @see [EncoderDecoder.Config]
          * */
-        public class Configuration private constructor(
+        public class Config private constructor(
             isLenient: Boolean,
             @JvmField
             public val acceptLowercase: Boolean,
@@ -244,7 +245,7 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             public val encodeToLowercase: Boolean,
             @JvmField
             public val padEncoded: Boolean,
-        ): EncoderDecoder.Configuration(isLenient, paddingByte = '='.byte) {
+        ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
             override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
                 return decodeOutMaxSize(encodedSize)
@@ -270,8 +271,8 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             internal companion object {
 
                 @JvmSynthetic
-                internal fun from(builder: Base32DefaultBuilder): Configuration {
-                    return Configuration(
+                internal fun from(builder: Base32DefaultConfigBuilder): Config {
+                    return Config(
                         isLenient = builder.isLenient,
                         acceptLowercase = builder.acceptLowercase,
                         encodeToLowercase = builder.encodeToLowercase,
@@ -346,20 +347,21 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
      *     assertEquals(text, decoded)
      *
      * @see [Base32Hex]
+     * @see [Hex.Config]
      * @see [CHARS]
      * @see [EncoderDecoder]
      * */
-    public class Hex(config: Hex.Configuration): Base32(config) {
+    public class Hex(config: Hex.Config): Base32(config) {
 
         /**
          * Configuration for [Base32.Hex] encoding/decoding.
          *
-         * Use [Base32HexBuilder] to create.
+         * Use [Base32HexConfigBuilder] to create.
          *
-         * @see [Base32HexBuilder]
-         * @see [EncoderDecoder.Configuration]
+         * @see [Base32HexConfigBuilder]
+         * @see [EncoderDecoder.Config]
          * */
-        public class Configuration private constructor(
+        public class Config private constructor(
             isLenient: Boolean,
             @JvmField
             public val acceptLowercase: Boolean,
@@ -367,7 +369,7 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             public val encodeToLowercase: Boolean,
             @JvmField
             public val padEncoded: Boolean,
-        ): EncoderDecoder.Configuration(isLenient, paddingByte = '='.byte) {
+        ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
             override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
                 return decodeOutMaxSize(encodedSize)
@@ -393,8 +395,8 @@ public sealed class Base32(config: EncoderDecoder.Configuration): EncoderDecoder
             internal companion object {
 
                 @JvmSynthetic
-                internal fun from(builder: Base32HexBuilder): Configuration {
-                    return Configuration(
+                internal fun from(builder: Base32HexConfigBuilder): Config {
+                    return Config(
                         isLenient = builder.isLenient,
                         acceptLowercase = builder.acceptLowercase,
                         encodeToLowercase = builder.encodeToLowercase,

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -49,13 +49,13 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *         isLenient = true
      *         acceptLowercase = true
      *         hyphenInterval = 5
-     *         setCheckByte(checkSymbol = '*')
+     *         checkByte(checkSymbol = '~')
      *     }
      *
      *     val text = "Hello World!"
      *     val bytes = text.encodeToByteArray()
      *     val encoded = bytes.encodeToString(base32Crockford)
-     *     println(encoded) // 91JPR-V3F41-BPYWK-CCGGG*
+     *     println(encoded) // 91JPR-V3F41-BPYWK-CCGGG~
      *     val decoded = encoded.decodeToArray(base32Crockford).decodeToString()
      *     assertEquals(text, decoded)
      *
@@ -109,16 +109,13 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
                 var outSize = encodedOutSize(unEncodedSize, willBePadded = false)
 
-                // TODO: Don't loop here... use maths
                 if (hyphenInterval > 0) {
-                    val interval = hyphenInterval.toInt()
-                    val size = outSize
-                    var count = 0
-                    var index = 0
-                    while (index++ < size) {
-                        if (count++ != interval) continue
-                        outSize++
-                        count = 0
+                    // TODO: This is still off because encodedOutSize returns Int
+                    //  will need to fix (Issue #48)
+                    val hyphenCount = (outSize / hyphenInterval) - 1
+
+                    if (hyphenCount > 0) {
+                        outSize += hyphenCount
                     }
                 }
 

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -79,6 +79,8 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             @JvmField
             public val acceptLowercase: Boolean,
             @JvmField
+            public val encodeToLowercase: Boolean,
+            @JvmField
             public val hyphenInterval: Short,
             @JvmField
             public val checkByte: Byte?,
@@ -132,6 +134,9 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                     append("    acceptLowercase: ")
                     append(acceptLowercase)
                     appendLine()
+                    append("    encodeToLowercase: ")
+                    append(encodeToLowercase)
+                    appendLine()
                     append("    hyphenInterval: ")
                     append(hyphenInterval)
                     appendLine()
@@ -147,6 +152,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                     return Config(
                         isLenient = builder.isLenient,
                         acceptLowercase = builder.acceptLowercase,
+                        encodeToLowercase = builder.encodeToLowercase,
                         hyphenInterval = builder.hyphenInterval,
                         checkByte = builder.checkByte
                     )

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -163,8 +163,19 @@ public class Base32CrockfordConfigBuilder {
     public var acceptLowercase: Boolean = false
 
     /**
-     * The interval at which hyphens ("-") should be inserted
-     * when encoding data.
+     * For every [hyphenInterval] of decoded output, a
+     * hyphen ("-") will be inserted.
+     *
+     * e.g.
+     *
+     *     hyphenInterval = 0
+     *     // 91JPRV3F41BPYWKCCGGG
+     *
+     *     hyphenInterval = 5
+     *     // 91JPR-V3F41-BPYWK-CCGGG
+     *
+     *     hyphenInterval = 4
+     *     // 91JP-RV3F-41BP-YWKC-CGGG
      *
      * Enable by setting to a value greater than 0.
      * */

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+//@file:Suppress("FunctionName", "SpellCheckingInspection")
+
+@file:Suppress("FunctionName", "SpellCheckingInspection")
+
+package io.matthewnelson.encoding.builders
+
+import io.matthewnelson.encoding.base32.Base32
+import io.matthewnelson.encoding.core.EncodingException
+import io.matthewnelson.encoding.core.util.byte
+import io.matthewnelson.encoding.core.util.char
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Builds a [Base32.Crockford] encoder/decoder.
+ *
+ * @param [config] inherit settings from.
+ * @see [Base32CrockfordBuilder]
+ * */
+public fun Base32Crockford(
+    config: Base32.Crockford.Configuration?,
+    block: Base32CrockfordBuilder.() -> Unit,
+): Base32.Crockford {
+    val builder = Base32CrockfordBuilder(config)
+    block.invoke(builder)
+    return Base32.Crockford(builder.build())
+}
+
+/**
+ * Builds a [Base32.Crockford] encoder/decoder.
+ *
+ * @see [Base32CrockfordBuilder]
+ * */
+public fun Base32Crockford(
+    block: Base32CrockfordBuilder.() -> Unit,
+): Base32.Crockford {
+    return Base32Crockford(config = null, block)
+}
+
+/**
+ * Builds a [Base32.Default] encoder/decoder.
+ *
+ * @param [config] to inherit from.
+ * @see [Base32DefaultBuilder]
+ * */
+public fun Base32Default(
+    config: Base32.Default.Configuration?,
+    block: Base32DefaultBuilder.() -> Unit,
+): Base32.Default {
+    val builder = Base32DefaultBuilder(config)
+    block.invoke(builder)
+    return Base32.Default(builder.build())
+}
+
+/**
+ * Builds a [Base32.Default] encoder/decoder.
+ *
+ * @see [Base32DefaultBuilder]
+ * */
+public fun Base32Default(
+    block: Base32DefaultBuilder.() -> Unit,
+): Base32.Default {
+    return Base32Default(config = null, block)
+}
+
+/**
+ * Builds a [Base32.Hex] encoder/decoder.
+ *
+ * @param [config] to inherit from.
+ * @see [Base32HexBuilder]
+ * */
+public fun Base32Hex(
+    config: Base32.Hex.Configuration?,
+    block: Base32HexBuilder.() -> Unit,
+): Base32.Hex {
+    val builder = Base32HexBuilder(config)
+    block.invoke(builder)
+    return Base32.Hex(builder.build())
+}
+
+/**
+ * Builds a [Base32.Hex] encoder/decoder.
+ *
+ * @see [Base32HexBuilder]
+ * */
+public fun Base32Hex(
+    block: Base32HexBuilder.() -> Unit,
+): Base32.Hex {
+    return Base32Hex(config = null, block)
+}
+
+/**
+ * Builder for configuring and then creating
+ * a [Base32.Crockford] encoder/decoder.
+ *
+ * @see [Base32Crockford]
+ * */
+public class Base32CrockfordBuilder {
+
+    public constructor()
+    public constructor(config: Base32.Crockford.Configuration?): this() {
+        if (config == null) return
+        isLenient = config.isLenient
+        acceptLowercase = config.acceptLowercase
+        hyphenInterval = config.hyphenInterval
+        checkByte = config.checkByte
+    }
+
+    /**
+     * If true, spaces and new lines ('\n', '\r', ' ', '\t')
+     * will be skipped over when decoding.
+     *
+     * If false, an [EncodingException] will be thrown if
+     * those characters are encountered when decoding.
+     * */
+    @JvmField
+    public var isLenient: Boolean = true
+
+    /**
+     * If true, will accept lowercase **AND** uppercase
+     * characters when decoding (against Crockford spec).
+     *
+     * If false, an [EncodingException] will be thrown if
+     * lowercase characters are encountered when decoding.
+     * */
+    @JvmField
+    public var acceptLowercase: Boolean = false
+
+    /**
+     * The interval at which hyphens ("-") should be inserted
+     * when encoding data.
+     *
+     * Enable by setting to a value greater than 0.
+     * */
+    @JvmField
+    public var hyphenInterval: Short = 0
+
+    @get:JvmSynthetic
+    internal var checkByte: Byte? = null
+    public val checkSymbol: Char? get() = checkByte?.char
+
+    /**
+     * Specify an optional check symbol to be appended to the encoded
+     * output, and verified when decoding (fail quickly).
+     *
+     * Valid check symbols are:
+     *  - '*', '~', '$', '=', 'U', 'u'
+     *  - or null to omit
+     *
+     * @throws [IllegalArgumentException] If not a valid check symbol.
+     * */
+    @Throws(IllegalArgumentException::class)
+    public fun setCheckSymbol(checkSymbol: Char?): Base32CrockfordBuilder {
+        when (checkSymbol) {
+            null, '*', '~', '$', '=', 'U', 'u' -> {
+                checkByte = checkSymbol?.byte
+            }
+            else -> {
+                throw IllegalArgumentException(
+                    "checkSymbol[$checkSymbol] not recognized.\n" +
+                    "Must be one of the following characters: *, ~, \$, =, U, u\n" +
+                    "OR null to omit"
+                )
+            }
+        }
+
+        return this
+    }
+
+    /**
+     * Builds a [Base32.Crockford] encoder/decoder for the
+     * given settings.
+     * */
+    public fun build(): Base32.Crockford.Configuration = Base32.Crockford.Configuration.from(this)
+}
+
+/**
+ * Builder for configuring and then creating
+ * a [Base32.Default] encoder/decoder.
+ *
+ * @see [Base32Default]
+ * */
+public class Base32DefaultBuilder {
+
+    public constructor()
+    public constructor(config: Base32.Default.Configuration?): this() {
+        if (config == null) return
+        isLenient = config.isLenient
+        acceptLowercase = config.acceptLowercase
+        encodeToLowercase = config.encodeToLowercase
+        padEncoded = config.padEncoded
+    }
+
+    /**
+     * If true, spaces and new lines ('\n', '\r', ' ', '\t')
+     * will be skipped over when decoding.
+     *
+     * If false, an [EncodingException] will be thrown if
+     * those characters are encountered when decoding.
+     * */
+    @JvmField
+    public var isLenient: Boolean = true
+
+    /**
+     * If true, will accept lowercase **AND** uppercase
+     * characters when decoding (against RFC 4648).
+     *
+     * If false, an [EncodingException] will be thrown if
+     * lowercase characters are encountered when decoding.
+     * */
+    @JvmField
+    public var acceptLowercase: Boolean = true
+
+    /**
+     * If true, will output lowercase characters when
+     * encoding (against RFC 4648).
+     *
+     * If false, will output uppercase characters when
+     * encoding.
+     * */
+    @JvmField
+    public var encodeToLowercase: Boolean = true
+
+    /**
+     * If true, padding **WILL** be applied to the encoded
+     * output.
+     *
+     * If false, padding **WILL NOT** be applied to the
+     * encoded output (against RFC 4648).
+     * */
+    @JvmField
+    public var padEncoded: Boolean = true
+
+    /**
+     * Builds a [Base32.Default] encoder/decoder for the
+     * given settings
+     * */
+    public fun build(): Base32.Default.Configuration = Base32.Default.Configuration.from(this)
+}
+
+/**
+ * Builder for configuring and then creating
+ * a [Base32.Hex] encoder/decoder.
+ *
+ * @see [Base32Hex]
+ * */
+public class Base32HexBuilder {
+
+    public constructor()
+    public constructor(config: Base32.Hex.Configuration?): this() {
+        if (config == null) return
+        isLenient = config.isLenient
+        acceptLowercase = config.acceptLowercase
+        encodeToLowercase = config.encodeToLowercase
+        padEncoded = config.padEncoded
+    }
+
+    /**
+     * If true, spaces and new lines ('\n', '\r', ' ', '\t')
+     * will be skipped over when decoding.
+     *
+     * If false, an [EncodingException] will be thrown if
+     * those characters are encountered when decoding.
+     * */
+    @JvmField
+    public var isLenient: Boolean = true
+
+    /**
+     * If true, will accept lowercase **AND** uppercase
+     * characters when decoding (against RFC 4648).
+     *
+     * If false, an [EncodingException] will be thrown if
+     * lowercase characters are encountered when decoding.
+     * */
+    @JvmField
+    public var acceptLowercase: Boolean = true
+
+    /**
+     * If true, will output lowercase characters when
+     * encoding (against RFC 4648).
+     *
+     * If false, will output uppercase characters when
+     * encoding.
+     * */
+    @JvmField
+    public var encodeToLowercase: Boolean = true
+
+    /**
+     * If true, padding **WILL** be applied to the encoded
+     * output.
+     *
+     * If false, padding **WILL NOT** be applied to the
+     * encoded output (against RFC 4648).
+     * */
+    @JvmField
+    public var padEncoded: Boolean = true
+
+    /**
+     * Builds a [Base32.Hex] encoder/decoder for the
+     * given settings.
+     * */
+    public fun build(): Base32.Hex.Configuration = Base32.Hex.Configuration.from(this)
+}

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -149,6 +149,7 @@ public class Base32CrockfordConfigBuilder {
         if (config == null) return
         isLenient = config.isLenient
         acceptLowercase = config.acceptLowercase
+        encodeToLowercase = config.encodeToLowercase
         hyphenInterval = config.hyphenInterval
         checkByte = config.checkByte
     }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -23,6 +23,7 @@ import io.matthewnelson.encoding.core.util.byte
 import io.matthewnelson.encoding.core.util.char
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
 
 /**
  * Creates a configured [Base32.Crockford] encoder/decoder.
@@ -54,9 +55,12 @@ public fun Base32Crockford(
  * Creates a configured [Base32.Crockford] encoder/decoder
  * using the default settings.
  *
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with the Crockford spec.
  * @see [Base32CrockfordConfigBuilder]
  * */
-public fun Base32Crockford(): Base32.Crockford = Base32Crockford {}
+@JvmOverloads
+public fun Base32Crockford(strict: Boolean = false): Base32.Crockford = Base32Crockford { if (strict) strict() }
 
 /**
  * Creates a configured [Base32.Default] encoder/decoder.
@@ -88,9 +92,12 @@ public fun Base32Default(
  * Creates a configured [Base32.Default] encoder/decoder
  * using the default settings.
  *
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
  * @see [Base32DefaultConfigBuilder]
  * */
-public fun Base32Default(): Base32.Default = Base32Default {}
+@JvmOverloads
+public fun Base32Default(strict: Boolean = false): Base32.Default = Base32Default { if (strict) strict() }
 
 /**
  * Creates a configured [Base32.Hex] encoder/decoder.
@@ -122,13 +129,17 @@ public fun Base32Hex(
  * Creates a configured [Base32.Hex] encoder/decoder
  * using the default settings.
  *
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
  * @see [Base32HexConfigBuilder]
  * */
-public fun Base32Hex(): Base32.Hex = Base32Hex {}
+@JvmOverloads
+public fun Base32Hex(strict: Boolean = false): Base32.Hex = Base32Hex { if (strict) strict() }
 
 /**
  * Builder for creating a [Base32.Crockford.Config].
  *
+ * @see [strict]
  * @see [Base32Crockford]
  * */
 public class Base32CrockfordConfigBuilder {
@@ -227,6 +238,17 @@ public class Base32CrockfordConfigBuilder {
     }
 
     /**
+     * A shortcut for configuring things to be in strict
+     * adherence with the Crockford spec.
+     * */
+    public fun strict(): Base32CrockfordConfigBuilder {
+        isLenient = false
+        acceptLowercase = false
+        encodeToLowercase = false
+        return this
+    }
+
+    /**
      * Builds a [Base32.Crockford.Config] for the provided settings.
      * */
     public fun build(): Base32.Crockford.Config = Base32.Crockford.Config.from(this)
@@ -235,6 +257,7 @@ public class Base32CrockfordConfigBuilder {
 /**
  * Builder for creating a [Base32.Default.Config].
  *
+ * @see [strict]
  * @see [Base32Default]
  * */
 public class Base32DefaultConfigBuilder {
@@ -289,6 +312,18 @@ public class Base32DefaultConfigBuilder {
     public var padEncoded: Boolean = true
 
     /**
+     * A shortcut for configuring things to be in strict
+     * adherence with RFC 4648.
+     * */
+    public fun strict(): Base32DefaultConfigBuilder {
+        isLenient = false
+        acceptLowercase = false
+        encodeToLowercase = false
+        padEncoded = true
+        return this
+    }
+
+    /**
      * Builds a [Base32.Default.Config] for the provided settings.
      * */
     public fun build(): Base32.Default.Config = Base32.Default.Config.from(this)
@@ -297,6 +332,7 @@ public class Base32DefaultConfigBuilder {
 /**
  * Builder for creating a [Base32.Hex.Config].
  *
+ * @see [strict]
  * @see [Base32Hex]
  * */
 public class Base32HexConfigBuilder {
@@ -349,6 +385,18 @@ public class Base32HexConfigBuilder {
      * */
     @JvmField
     public var padEncoded: Boolean = true
+
+    /**
+     * A shortcut for configuring things to be in strict
+     * adherence with RFC 4648.
+     * */
+    public fun strict(): Base32HexConfigBuilder {
+        isLenient = false
+        acceptLowercase = false
+        encodeToLowercase = false
+        padEncoded = true
+        return this
+    }
 
     /**
      * Builds a [Base32.Hex.Config] for the provided settings.

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-//@file:Suppress("FunctionName", "SpellCheckingInspection")
-
 @file:Suppress("FunctionName", "SpellCheckingInspection")
 
 package io.matthewnelson.encoding.builders
@@ -27,7 +25,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmSynthetic
 
 /**
- * Builds a [Base32.Crockford] encoder/decoder.
+ * Creates a configured [Base32.Crockford] encoder/decoder.
  *
  * @param [config] inherit settings from.
  * @see [Base32CrockfordBuilder]
@@ -42,7 +40,7 @@ public fun Base32Crockford(
 }
 
 /**
- * Builds a [Base32.Crockford] encoder/decoder.
+ * Creates a configured [Base32.Crockford] encoder/decoder.
  *
  * @see [Base32CrockfordBuilder]
  * */
@@ -53,7 +51,7 @@ public fun Base32Crockford(
 }
 
 /**
- * Builds a [Base32.Default] encoder/decoder.
+ * Creates a configured [Base32.Default] encoder/decoder.
  *
  * @param [config] to inherit from.
  * @see [Base32DefaultBuilder]
@@ -68,7 +66,7 @@ public fun Base32Default(
 }
 
 /**
- * Builds a [Base32.Default] encoder/decoder.
+ * Creates a configured [Base32.Default] encoder/decoder.
  *
  * @see [Base32DefaultBuilder]
  * */
@@ -79,7 +77,7 @@ public fun Base32Default(
 }
 
 /**
- * Builds a [Base32.Hex] encoder/decoder.
+ * Creates a configured [Base32.Hex] encoder/decoder.
  *
  * @param [config] to inherit from.
  * @see [Base32HexBuilder]
@@ -94,7 +92,7 @@ public fun Base32Hex(
 }
 
 /**
- * Builds a [Base32.Hex] encoder/decoder.
+ * Creates a configured [Base32.Hex] encoder/decoder.
  *
  * @see [Base32HexBuilder]
  * */
@@ -105,8 +103,7 @@ public fun Base32Hex(
 }
 
 /**
- * Builder for configuring and then creating
- * a [Base32.Crockford] encoder/decoder.
+ * Builder for creating a [Base32.Crockford.Configuration].
  *
  * @see [Base32Crockford]
  * */
@@ -183,15 +180,13 @@ public class Base32CrockfordBuilder {
     }
 
     /**
-     * Builds a [Base32.Crockford] encoder/decoder for the
-     * given settings.
+     * Builds a [Base32.Crockford.Configuration] for the provided settings.
      * */
     public fun build(): Base32.Crockford.Configuration = Base32.Crockford.Configuration.from(this)
 }
 
 /**
- * Builder for configuring and then creating
- * a [Base32.Default] encoder/decoder.
+ * Builder for creating a [Base32.Default.Configuration].
  *
  * @see [Base32Default]
  * */
@@ -247,15 +242,13 @@ public class Base32DefaultBuilder {
     public var padEncoded: Boolean = true
 
     /**
-     * Builds a [Base32.Default] encoder/decoder for the
-     * given settings
+     * Builds a [Base32.Default.Configuration] for the provided settings.
      * */
     public fun build(): Base32.Default.Configuration = Base32.Default.Configuration.from(this)
 }
 
 /**
- * Builder for configuring and then creating
- * a [Base32.Hex] encoder/decoder.
+ * Builder for creating a [Base32.Hex.Configuration].
  *
  * @see [Base32Hex]
  * */
@@ -311,8 +304,7 @@ public class Base32HexBuilder {
     public var padEncoded: Boolean = true
 
     /**
-     * Builds a [Base32.Hex] encoder/decoder for the
-     * given settings.
+     * Builds a [Base32.Hex.Configuration] for the provided settings.
      * */
     public fun build(): Base32.Hex.Configuration = Base32.Hex.Configuration.from(this)
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -28,13 +28,13 @@ import kotlin.jvm.JvmName
  * Creates a configured [Base32.Crockford] encoder/decoder.
  *
  * @param [config] inherit settings from.
- * @see [Base32CrockfordBuilder]
+ * @see [Base32CrockfordConfigBuilder]
  * */
 public fun Base32Crockford(
-    config: Base32.Crockford.Configuration?,
-    block: Base32CrockfordBuilder.() -> Unit,
+    config: Base32.Crockford.Config?,
+    block: Base32CrockfordConfigBuilder.() -> Unit,
 ): Base32.Crockford {
-    val builder = Base32CrockfordBuilder(config)
+    val builder = Base32CrockfordConfigBuilder(config)
     block.invoke(builder)
     return Base32.Crockford(builder.build())
 }
@@ -42,25 +42,33 @@ public fun Base32Crockford(
 /**
  * Creates a configured [Base32.Crockford] encoder/decoder.
  *
- * @see [Base32CrockfordBuilder]
+ * @see [Base32CrockfordConfigBuilder]
  * */
 public fun Base32Crockford(
-    block: Base32CrockfordBuilder.() -> Unit,
+    block: Base32CrockfordConfigBuilder.() -> Unit,
 ): Base32.Crockford {
     return Base32Crockford(config = null, block)
 }
 
 /**
+ * Creates a configured [Base32.Crockford] encoder/decoder
+ * using the default settings.
+ *
+ * @see [Base32CrockfordConfigBuilder]
+ * */
+public fun Base32Crockford(): Base32.Crockford = Base32Crockford {}
+
+/**
  * Creates a configured [Base32.Default] encoder/decoder.
  *
  * @param [config] to inherit from.
- * @see [Base32DefaultBuilder]
+ * @see [Base32DefaultConfigBuilder]
  * */
 public fun Base32Default(
-    config: Base32.Default.Configuration?,
-    block: Base32DefaultBuilder.() -> Unit,
+    config: Base32.Default.Config?,
+    block: Base32DefaultConfigBuilder.() -> Unit,
 ): Base32.Default {
-    val builder = Base32DefaultBuilder(config)
+    val builder = Base32DefaultConfigBuilder(config)
     block.invoke(builder)
     return Base32.Default(builder.build())
 }
@@ -68,25 +76,33 @@ public fun Base32Default(
 /**
  * Creates a configured [Base32.Default] encoder/decoder.
  *
- * @see [Base32DefaultBuilder]
+ * @see [Base32DefaultConfigBuilder]
  * */
 public fun Base32Default(
-    block: Base32DefaultBuilder.() -> Unit,
+    block: Base32DefaultConfigBuilder.() -> Unit,
 ): Base32.Default {
     return Base32Default(config = null, block)
 }
 
 /**
+ * Creates a configured [Base32.Default] encoder/decoder
+ * using the default settings.
+ *
+ * @see [Base32DefaultConfigBuilder]
+ * */
+public fun Base32Default(): Base32.Default = Base32Default {}
+
+/**
  * Creates a configured [Base32.Hex] encoder/decoder.
  *
  * @param [config] to inherit from.
- * @see [Base32HexBuilder]
+ * @see [Base32HexConfigBuilder]
  * */
 public fun Base32Hex(
-    config: Base32.Hex.Configuration?,
-    block: Base32HexBuilder.() -> Unit,
+    config: Base32.Hex.Config?,
+    block: Base32HexConfigBuilder.() -> Unit,
 ): Base32.Hex {
-    val builder = Base32HexBuilder(config)
+    val builder = Base32HexConfigBuilder(config)
     block.invoke(builder)
     return Base32.Hex(builder.build())
 }
@@ -94,23 +110,31 @@ public fun Base32Hex(
 /**
  * Creates a configured [Base32.Hex] encoder/decoder.
  *
- * @see [Base32HexBuilder]
+ * @see [Base32HexConfigBuilder]
  * */
 public fun Base32Hex(
-    block: Base32HexBuilder.() -> Unit,
+    block: Base32HexConfigBuilder.() -> Unit,
 ): Base32.Hex {
     return Base32Hex(config = null, block)
 }
 
 /**
- * Builder for creating a [Base32.Crockford.Configuration].
+ * Creates a configured [Base32.Hex] encoder/decoder
+ * using the default settings.
+ *
+ * @see [Base32HexConfigBuilder]
+ * */
+public fun Base32Hex(): Base32.Hex = Base32Hex {}
+
+/**
+ * Builder for creating a [Base32.Crockford.Config].
  *
  * @see [Base32Crockford]
  * */
-public class Base32CrockfordBuilder {
+public class Base32CrockfordConfigBuilder {
 
     public constructor()
-    public constructor(config: Base32.Crockford.Configuration?): this() {
+    public constructor(config: Base32.Crockford.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient
         acceptLowercase = config.acceptLowercase
@@ -164,7 +188,7 @@ public class Base32CrockfordBuilder {
      * @throws [IllegalArgumentException] If not a valid check symbol.
      * */
     @Throws(IllegalArgumentException::class)
-    public fun checkByte(checkSymbol: Char?): Base32CrockfordBuilder {
+    public fun checkByte(checkSymbol: Char?): Base32CrockfordConfigBuilder {
         when (checkSymbol) {
             null, '*', '~', '$', '=', 'U', 'u' -> {
                 checkByte = checkSymbol?.byte
@@ -182,20 +206,20 @@ public class Base32CrockfordBuilder {
     }
 
     /**
-     * Builds a [Base32.Crockford.Configuration] for the provided settings.
+     * Builds a [Base32.Crockford.Config] for the provided settings.
      * */
-    public fun build(): Base32.Crockford.Configuration = Base32.Crockford.Configuration.from(this)
+    public fun build(): Base32.Crockford.Config = Base32.Crockford.Config.from(this)
 }
 
 /**
- * Builder for creating a [Base32.Default.Configuration].
+ * Builder for creating a [Base32.Default.Config].
  *
  * @see [Base32Default]
  * */
-public class Base32DefaultBuilder {
+public class Base32DefaultConfigBuilder {
 
     public constructor()
-    public constructor(config: Base32.Default.Configuration?): this() {
+    public constructor(config: Base32.Default.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient
         acceptLowercase = config.acceptLowercase
@@ -244,20 +268,20 @@ public class Base32DefaultBuilder {
     public var padEncoded: Boolean = true
 
     /**
-     * Builds a [Base32.Default.Configuration] for the provided settings.
+     * Builds a [Base32.Default.Config] for the provided settings.
      * */
-    public fun build(): Base32.Default.Configuration = Base32.Default.Configuration.from(this)
+    public fun build(): Base32.Default.Config = Base32.Default.Config.from(this)
 }
 
 /**
- * Builder for creating a [Base32.Hex.Configuration].
+ * Builder for creating a [Base32.Hex.Config].
  *
  * @see [Base32Hex]
  * */
-public class Base32HexBuilder {
+public class Base32HexConfigBuilder {
 
     public constructor()
-    public constructor(config: Base32.Hex.Configuration?): this() {
+    public constructor(config: Base32.Hex.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient
         acceptLowercase = config.acceptLowercase
@@ -306,7 +330,7 @@ public class Base32HexBuilder {
     public var padEncoded: Boolean = true
 
     /**
-     * Builds a [Base32.Hex.Configuration] for the provided settings.
+     * Builds a [Base32.Hex.Config] for the provided settings.
      * */
-    public fun build(): Base32.Hex.Configuration = Base32.Hex.Configuration.from(this)
+    public fun build(): Base32.Hex.Config = Base32.Hex.Config.from(this)
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -22,7 +22,7 @@ import io.matthewnelson.encoding.core.EncodingException
 import io.matthewnelson.encoding.core.util.byte
 import io.matthewnelson.encoding.core.util.char
 import kotlin.jvm.JvmField
-import kotlin.jvm.JvmSynthetic
+import kotlin.jvm.JvmName
 
 /**
  * Creates a configured [Base32.Crockford] encoder/decoder.
@@ -147,8 +147,10 @@ public class Base32CrockfordBuilder {
     @JvmField
     public var hyphenInterval: Short = 0
 
-    @get:JvmSynthetic
-    internal var checkByte: Byte? = null
+    @get:JvmName("checkByte")
+    public var checkByte: Byte? = null
+        private set
+    @get:JvmName("checkSymbol")
     public val checkSymbol: Char? get() = checkByte?.char
 
     /**
@@ -162,7 +164,7 @@ public class Base32CrockfordBuilder {
      * @throws [IllegalArgumentException] If not a valid check symbol.
      * */
     @Throws(IllegalArgumentException::class)
-    public fun setCheckSymbol(checkSymbol: Char?): Base32CrockfordBuilder {
+    public fun checkByte(checkSymbol: Char?): Base32CrockfordBuilder {
         when (checkSymbol) {
             null, '*', '~', '$', '=', 'U', 'u' -> {
                 checkByte = checkSymbol?.byte

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -160,7 +160,17 @@ public class Base32CrockfordConfigBuilder {
      * lowercase characters are encountered when decoding.
      * */
     @JvmField
-    public var acceptLowercase: Boolean = false
+    public var acceptLowercase: Boolean = true
+
+    /**
+     * If true, will output lowercase characters when
+     * encoding (against Crockford spec).
+     *
+     * If false, will output uppercase characters when
+     * encoding.
+     * */
+    @JvmField
+    public var encodeToLowercase: Boolean = true
 
     /**
      * For every [hyphenInterval] of decoded output, a

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -1,13 +1,13 @@
 public abstract class io/matthewnelson/encoding/core/Decoder {
 	public static final field Companion Lio/matthewnelson/encoding/core/Decoder$Companion;
-	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun decodeToArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
-	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;
+	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Config;
 	public abstract fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
 }
 
@@ -27,7 +27,7 @@ public abstract class io/matthewnelson/encoding/core/Decoder$Feed : io/matthewne
 
 public abstract class io/matthewnelson/encoding/core/Encoder : io/matthewnelson/encoding/core/Decoder {
 	public static final field Companion Lio/matthewnelson/encoding/core/Encoder$Companion;
-	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun encodeToByteArray ([BLio/matthewnelson/encoding/core/Encoder;)[B
 	public static final fun encodeToCharArray ([BLio/matthewnelson/encoding/core/Encoder;)[C
 	public static final fun encodeToString ([BLio/matthewnelson/encoding/core/Encoder;)Ljava/lang/String;
@@ -48,14 +48,14 @@ public abstract class io/matthewnelson/encoding/core/Encoder$Feed : io/matthewne
 }
 
 public abstract class io/matthewnelson/encoding/core/EncoderDecoder : io/matthewnelson/encoding/core/Encoder {
-	public fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;)V
+	public fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)V
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	protected abstract fun name ()Ljava/lang/String;
 	public final fun toString ()Ljava/lang/String;
 }
 
-public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Configuration {
+public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field isLenient Z
 	public final field paddingByte Ljava/lang/Byte;
 	public fun <init> (ZLjava/lang/Byte;)V
@@ -103,7 +103,7 @@ public abstract interface annotation class io/matthewnelson/encoding/core/intern
 
 public final class io/matthewnelson/encoding/core/util/DecoderInput {
 	public static final field Companion Lio/matthewnelson/encoding/core/util/DecoderInput$Companion;
-	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Configuration;Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun get (I)C
 }
 

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -60,7 +60,8 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Configuratio
 	public final field paddingByte Ljava/lang/Byte;
 	public fun <init> (ZLjava/lang/Byte;)V
 	public abstract fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
-	public abstract fun encodeOutSize (I)I
+	public final fun encodeOutSize (I)I
+	protected abstract fun encodeOutSizeProtected (I)I
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public final fun toString ()Ljava/lang/String;

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -31,7 +31,7 @@ import kotlin.jvm.JvmStatic
  * @see [Feed]
  * @see [newDecoderFeed]
  * */
-public sealed class Decoder(public val config: EncoderDecoder.Configuration) {
+public sealed class Decoder(public val config: EncoderDecoder.Config) {
 
     /**
      * Creates a new [Decoder.Feed] for the [Decoder], outputting
@@ -53,6 +53,7 @@ public sealed class Decoder(public val config: EncoderDecoder.Configuration) {
      * finalization for leftover data still in the [Decoder.Feed]
      * implementation's buffer.
      *
+     * @see [newDecoderFeed]
      * @see [EncoderDecoder.Feed]
      * @see [use]
      * */

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -30,7 +30,7 @@ import kotlin.jvm.JvmStatic
  * @see [Feed]
  * @see [newEncoderFeed]
  * */
-public sealed class Encoder(config: EncoderDecoder.Configuration): Decoder(config) {
+public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
 
     /**
      * Creates a new [Encoder.Feed] for the [Encoder], outputting
@@ -52,6 +52,7 @@ public sealed class Encoder(config: EncoderDecoder.Configuration): Decoder(confi
      * finalization for leftover data still in the [Encoder.Feed]
      * implementation's buffer.
      *
+     * @see [newEncoderFeed]
      * @see [EncoderDecoder.Feed]
      * @see [use]
      * */

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -80,12 +80,20 @@ constructor(config: Configuration): Encoder(config) {
         @Throws(EncodingException::class)
         public abstract fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int
 
+        protected abstract fun encodeOutSizeProtected(unEncodedSize: Int): Int
+
         /**
          * Calculates and returns the size of the output after encoding
-         * occurs, based off of the configuration options set for the
-         * [Configuration] implementation.
+         * occurs based off of the configuration options set.
          * */
-        public abstract fun encodeOutSize(unEncodedSize: Int): Int
+        public fun encodeOutSize(unEncodedSize: Int): Int {
+            return if (unEncodedSize <= 0) {
+                0
+            } else {
+                encodeOutSizeProtected(unEncodedSize)
+            }
+        }
+
 
         /**
          * Will be called whenever [toString] is invoked, allowing

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -26,13 +26,13 @@ import kotlin.jvm.JvmName
  * Base abstraction which expose [Encoder] and [Decoder] (sealed
  * classes) such that inheriting classes must implement both.
  *
- * @see [Configuration]
+ * @see [Config]
  * @see [Feed]
  * @sample [io.matthewnelson.encoding.base16.Base16]
  * */
 public abstract class EncoderDecoder
 @ExperimentalEncodingApi
-constructor(config: Configuration): Encoder(config) {
+constructor(config: Config): Encoder(config) {
 
     /**
      * The name of the [EncoderDecoder]. Utilized in the
@@ -57,9 +57,10 @@ constructor(config: Configuration): Encoder(config) {
      *   the given encoding; NOT "if padding should be
      *   used". (e.g. '='.code.toByte()).
      *   If the encoding specification does not ues padding, pass `null`.
-     * @sample [io.matthewnelson.encoding.base16.Base16.Configuration]
+     * @sample [io.matthewnelson.encoding.base16.Base16.Config]
+     * @sample [io.matthewnelson.encoding.base32.Base32.Default.Config]
      * */
-    public abstract class Configuration
+    public abstract class Config
     @ExperimentalEncodingApi
     constructor(
         @JvmField
@@ -71,7 +72,9 @@ constructor(config: Configuration): Encoder(config) {
         /**
          * Calculates and returns the maximum size of the output after
          * decoding occurs, based off of the configuration options set
-         * for the [Configuration] implementation.
+         * for the [Config] implementation.
+         *
+         * // TODO: Should accept Long and return Long
          *
          * @see [DecoderInput]
          * @param [encodedSize] size of the data being decoded.
@@ -86,6 +89,8 @@ constructor(config: Configuration): Encoder(config) {
         /**
          * Calculates and returns the size of the output after encoding
          * occurs based off of the configuration options set.
+         *
+         * TODO: Should accept Long and return Long
          * */
         public fun encodeOutSize(unEncodedSize: Int): Int {
             return if (unEncodedSize <= 0) {
@@ -98,7 +103,7 @@ constructor(config: Configuration): Encoder(config) {
 
         /**
          * Will be called whenever [toString] is invoked, allowing
-         * inheritors of [Configuration] to add their settings to
+         * inheritors of [Config] to add their settings to
          * the output.
          *
          * [isLenient] and [paddingByte] are automatically added.
@@ -120,12 +125,12 @@ constructor(config: Configuration): Encoder(config) {
          *   }
          *
          * @see [toString]
-         * @sample [io.matthewnelson.encoding.base16.Base16.Configuration.toStringAddSettings]
+         * @sample [io.matthewnelson.encoding.base16.Base16.Config.toStringAddSettings]
          * */
         protected abstract fun toStringAddSettings(sb: StringBuilder)
 
         final override fun equals(other: Any?): Boolean {
-            return  other is Configuration
+            return  other is Config
                     && other::class == this::class
                     && other.toString() == toString()
         }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -126,6 +126,7 @@ constructor(config: Config): Encoder(config) {
          *
          * @see [toString]
          * @sample [io.matthewnelson.encoding.base16.Base16.Config.toStringAddSettings]
+         * @sample [io.matthewnelson.encoding.base32.Base32.Crockford.Config.toStringAddSettings]
          * */
         protected abstract fun toStringAddSettings(sb: StringBuilder)
 

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -85,7 +85,7 @@ constructor(config: Configuration): Encoder(config) {
          * occurs, based off of the configuration options set for the
          * [Configuration] implementation.
          * */
-        public abstract fun encodeOutSize(unencodedSize: Int): Int
+        public abstract fun encodeOutSize(unEncodedSize: Int): Int
 
         /**
          * Will be called whenever [toString] is invoked, allowing

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -20,6 +20,7 @@ package io.matthewnelson.encoding.core
 import io.matthewnelson.encoding.core.util.DecoderInput
 import io.matthewnelson.encoding.core.util.char
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmName
 
 /**
  * Base abstraction which expose [Encoder] and [Decoder] (sealed
@@ -183,6 +184,7 @@ constructor(config: Configuration): Encoder(config) {
      * @see [Decoder.Feed]
      * */
     public sealed class Feed {
+        @get:JvmName("isClosed")
         public var isClosed: Boolean = false
             private set
 

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -91,9 +91,11 @@ private constructor(
             break
         }
 
-        val size = config.decodeOutMaxSizeOrFail(limit, this)
-
-        decodeOutMaxSize = if (size < 0) 0 else size
+        decodeOutMaxSize = if (limit == 0) {
+            0
+        } else {
+            config.decodeOutMaxSizeOrFail(limit, this)
+        }
     }
 
     public companion object {

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -24,21 +24,21 @@ import kotlin.jvm.JvmSynthetic
 /**
  * Helper class for analyzing encoded data in order to
  * determine the maximum output size based off of the
- * options set for provided [EncoderDecoder.Configuration].
+ * options set for provided [EncoderDecoder.Config].
  *
  * Will "strip" padding (if the config specifies it) and
  * spaces/new lines from the end in order to provide
- * [EncoderDecoder.Configuration.decodeOutMaxSizeOrFail]
+ * [EncoderDecoder.Config.decodeOutMaxSizeOrFail]
  * with the best guess at input size.
  *
  * @see [get]
- * @see [EncoderDecoder.Configuration.decodeOutMaxSizeOrFail]
+ * @see [EncoderDecoder.Config.decodeOutMaxSizeOrFail]
  * */
 @OptIn(InternalEncodingApi::class)
 public class DecoderInput
 @Throws(EncodingException::class)
 private constructor(
-    config: EncoderDecoder.Configuration,
+    config: EncoderDecoder.Config,
     private val input: Any
 ) {
 
@@ -46,7 +46,7 @@ private constructor(
     internal val decodeOutMaxSize: Int
 
     /**
-     * Can be utilized by [EncoderDecoder.Configuration]
+     * Can be utilized by [EncoderDecoder.Config]
      * implementation to check [input] in order to fail
      * early.
      * */
@@ -94,6 +94,9 @@ private constructor(
         decodeOutMaxSize = if (limit == 0) {
             0
         } else {
+            // TODO: Decoder implementation could have an overflow
+            //  and return negative here. Must still check negative
+            //  and throw.
             config.decodeOutMaxSizeOrFail(limit, this)
         }
     }
@@ -109,19 +112,19 @@ private constructor(
         @JvmSynthetic
         @Throws(EncodingException::class)
         internal fun String.toInputAnalysis(
-            config: EncoderDecoder.Configuration
+            config: EncoderDecoder.Config
         ): DecoderInput = DecoderInput(config, this)
 
         @JvmSynthetic
         @Throws(EncodingException::class)
         internal fun CharArray.toInputAnalysis(
-            config: EncoderDecoder.Configuration
+            config: EncoderDecoder.Config
         ): DecoderInput = DecoderInput(config, this)
 
         @JvmSynthetic
         @Throws(EncodingException::class)
         internal fun ByteArray.toInputAnalysis(
-            config: EncoderDecoder.Configuration
+            config: EncoderDecoder.Config
         ): DecoderInput = DecoderInput(config, this)
     }
 }


### PR DESCRIPTION
Part 1 of #41 

Wanted a "check point" here, as before continuing with the actual encoding/decoding implementation, #48 needs to be taken care of.

This PR:
 - Stubs in the implementation for `Base32` encoding
 - Reworks the builder patter for `Base16`
     - Found that when stubbing in things for the `Base32` implementation, some things were off 
       and to remain consistent across modules, needed to update it.
 - Renames `EncoderDecoder.Configuration` -> `EncoderDecoder.Config`
 - Cleans up documentation & code