### PR TITLE
Change `EncoderDecoder` pre-calculation input/output types to `Long`

### DIFF
--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -21,7 +21,6 @@ public final class io/matthewnelson/encoding/base16/Base16$Config : io/matthewne
 	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
 	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
 
 public final class io/matthewnelson/encoding/builders/Base16ConfigBuilder {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -73,7 +73,7 @@ public class Base16(config: Config): EncoderDecoder(config) {
         public val encodeToLowercase: Boolean,
     ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
-        override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int = encodedSize / 2
+        override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int = encodedSize / 2
         override fun encodeOutSizeProtected(unEncodedSize: Int): Int = unEncodedSize * 2
 
         override fun toStringAddSettings(sb: StringBuilder) {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -79,9 +79,7 @@ public class Base16(config: Config): EncoderDecoder(config) {
         @Throws(EncodingSizeException::class)
         override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
             if (unEncodedSize > (Long.MAX_VALUE / 2)) {
-                throw EncodingSizeException(
-                    "unEncodedSize[$unEncodedSize] would exceed the maximum[${Long.MAX_VALUE}] when encoded"
-                )
+                throw DecoderInput.outSizeExceedsMaxEncodingSizeException(unEncodedSize, Long.MAX_VALUE)
             }
 
             return unEncodedSize * 2L

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -73,8 +73,19 @@ public class Base16(config: Config): EncoderDecoder(config) {
         public val encodeToLowercase: Boolean,
     ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
-        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int = encodedSize / 2
-        override fun encodeOutSizeProtected(unEncodedSize: Int): Int = unEncodedSize * 2
+        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+            return encodedSize / 2L
+        }
+        @Throws(EncodingSizeException::class)
+        override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
+            if (unEncodedSize > (Long.MAX_VALUE / 2)) {
+                throw EncodingSizeException(
+                    "unEncodedSize[$unEncodedSize] would exceed the maximum[${Long.MAX_VALUE}] when encoded"
+                )
+            }
+
+            return unEncodedSize * 2L
+        }
 
         override fun toStringAddSettings(sb: StringBuilder) {
             with(sb) {
@@ -87,6 +98,7 @@ public class Base16(config: Config): EncoderDecoder(config) {
         }
 
         internal companion object {
+
             @JvmSynthetic
             internal fun from(builder: Base16ConfigBuilder): Config {
                 return Config(

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -49,9 +49,9 @@ import kotlin.jvm.JvmSynthetic
  *     val decoded = encoded.decodeToArray(base16).decodeToString()
  *     assertEquals(text, decoded)
  *
- * @see [Base16ConfigBuilder]
- * @see [Config]
- * @see [CHARS]
+ * @see [io.matthewnelson.encoding.builders.Base16]
+ * @see [Base16.Config]
+ * @see [Base16.CHARS]
  * @see [EncoderDecoder]
  * */
 @OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
@@ -73,7 +73,7 @@ public class Base16(config: Config): EncoderDecoder(config) {
         public val encodeToLowercase: Boolean,
     ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
-        override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int = encodedSize / 2
+        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int = encodedSize / 2
         override fun encodeOutSizeProtected(unEncodedSize: Int): Int = unEncodedSize * 2
 
         override fun toStringAddSettings(sb: StringBuilder) {

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -71,7 +71,6 @@ public final class io/matthewnelson/encoding/base32/Base32$Crockford$Config : io
 	public final field hyphenInterval S
 	public synthetic fun <init> (ZZZSLjava/lang/Byte;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun checkSymbol ()Ljava/lang/Character;
-	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Default : io/matthewnelson/encoding/base32/Base32 {
@@ -90,7 +89,6 @@ public final class io/matthewnelson/encoding/base32/Base32$Default$Config : io/m
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
 	public synthetic fun <init> (ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelson/encoding/base32/Base32 {
@@ -109,7 +107,6 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex$Config : io/matth
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
 	public synthetic fun <init> (ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 }
 
 public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder {

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -91,10 +91,10 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val checkSymbol: Char? get() = checkByte?.char
 
             @Throws(EncodingException::class)
-            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
+            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int {
                 var outSize = encodedSize
 
-                if (checkByte != null) {
+                if (input != null && checkByte != null) {
                     // Check last character
                     val actual = input[encodedSize - 1]
                     if (actual != checkByte.char) {
@@ -251,7 +251,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
+            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int {
                 return decodeOutMaxSize(encodedSize)
             }
 
@@ -375,7 +375,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int {
+            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int {
                 return decodeOutMaxSize(encodedSize)
             }
 

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -91,12 +91,12 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val checkSymbol: Char? get() = checkByte?.char
 
             @Throws(EncodingException::class)
-            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int {
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
                 var outSize = encodedSize
 
                 if (input != null && checkByte != null) {
                     // Check last character
-                    val actual = input[encodedSize - 1]
+                    val actual = input[encodedSize.toInt() - 1]
                     if (actual != checkByte.char) {
                         throw EncodingException(
                             "checkSymbol[$actual] for encoded did not match expected[${checkByte.char}]"
@@ -109,7 +109,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                 return decodeOutMaxSize(outSize)
             }
 
-            override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
+            override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
                 var outSize = encodedOutSize(unEncodedSize, willBePadded = false)
 
                 if (hyphenInterval > 0) {
@@ -251,11 +251,11 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int {
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
                 return decodeOutMaxSize(encodedSize)
             }
 
-            override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
+            override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
                 return encodedOutSize(unEncodedSize, padEncoded)
             }
 
@@ -375,11 +375,11 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int {
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
                 return decodeOutMaxSize(encodedSize)
             }
 
-            override fun encodeOutSizeProtected(unEncodedSize: Int): Int {
+            override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
                 return encodedOutSize(unEncodedSize, padEncoded)
             }
 
@@ -455,22 +455,22 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
     private companion object {
 
         @JvmStatic
-        private fun decodeOutMaxSize(encodedSize: Int): Int = (encodedSize * 5L / 8L).toInt()
+        private fun decodeOutMaxSize(encodedSize: Long): Long = (encodedSize * 5L / 8L)
 
         @JvmStatic
         private fun encodedOutSize(
-            unEncodedSize: Int,
+            unEncodedSize: Long,
             willBePadded: Boolean,
-        ): Int {
-            var outSize = (unEncodedSize + 4) / 5 * 8
+        ): Long {
+            var outSize = (unEncodedSize + 4L) / 5L * 8L
             if (willBePadded) return outSize
 
             when (unEncodedSize - (unEncodedSize - unEncodedSize % 5)) {
-                0 -> { /* no-op */ }
-                1 -> outSize -= 6
-                2 -> outSize -= 4
-                3 -> outSize -= 3
-                4 -> outSize -= 1
+                0L -> { /* no-op */ }
+                1L -> outSize -= 6L
+                2L -> outSize -= 4L
+                3L -> outSize -= 3L
+                4L -> outSize -= 1L
             }
 
             return outSize

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -62,7 +62,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *
      * @see [Base32Crockford]
      * @see [Crockford.Config]
-     * @see [CHARS]
+     * @see [Crockford.CHARS]
      * @see [EncoderDecoder]
      * */
     public class Crockford(config: Crockford.Config): Base32(config) {
@@ -91,7 +91,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val checkSymbol: Char? get() = checkByte?.char
 
             @Throws(EncodingException::class)
-            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int {
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int {
                 var outSize = encodedSize
 
                 if (input != null && checkByte != null) {
@@ -228,7 +228,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *
      * @see [Base32Default]
      * @see [Default.Config]
-     * @see [CHARS]
+     * @see [Default.CHARS]
      * @see [EncoderDecoder]
      * */
     public class Default(config: Default.Config): Base32(config) {
@@ -251,7 +251,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int {
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int {
                 return decodeOutMaxSize(encodedSize)
             }
 
@@ -352,7 +352,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *
      * @see [Base32Hex]
      * @see [Hex.Config]
-     * @see [CHARS]
+     * @see [Hex.CHARS]
      * @see [EncoderDecoder]
      * */
     public class Hex(config: Hex.Config): Base32(config) {
@@ -375,7 +375,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int {
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int {
                 return decodeOutMaxSize(encodedSize)
             }
 

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -113,12 +113,16 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                 var outSize = encodedOutSize(unEncodedSize, willBePadded = false)
 
                 if (hyphenInterval > 0) {
-                    // TODO: This is still off because encodedOutSize returns Int
-                    //  will need to fix (Issue #48)
-                    val hyphenCount = (outSize / hyphenInterval) - 1
+                    val hyphenCount: Float = (outSize.toFloat() / hyphenInterval) - 1F
 
-                    if (hyphenCount > 0) {
-                        outSize += hyphenCount
+                    if (hyphenCount > 0F) {
+                        // Count rounded down
+                        outSize += hyphenCount.toLong()
+
+                        // If there was a remainder, manually add it
+                        if (hyphenCount.rem(1) > 0F) {
+                            outSize++
+                        }
                     }
                 }
 
@@ -462,7 +466,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             unEncodedSize: Long,
             willBePadded: Boolean,
         ): Long {
-            var outSize = (unEncodedSize + 4L) / 5L * 8L
+            var outSize: Long = ((unEncodedSize + 4L) / 5L) * 8L
             if (willBePadded) return outSize
 
             when (unEncodedSize - (unEncodedSize - unEncodedSize % 5)) {

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -59,7 +59,8 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field isLenient Z
 	public final field paddingByte Ljava/lang/Byte;
 	public fun <init> (ZLjava/lang/Byte;)V
-	public abstract fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+	public final fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+	protected abstract fun decodeOutMaxSizeOrFailProtected (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
 	public final fun encodeOutSize (I)I
 	protected abstract fun encodeOutSizeProtected (I)I
 	public final fun equals (Ljava/lang/Object;)Z
@@ -77,10 +78,15 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Feed {
 	protected abstract fun updateProtected (B)V
 }
 
-public final class io/matthewnelson/encoding/core/EncodingException : java/lang/RuntimeException {
+public class io/matthewnelson/encoding/core/EncodingException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun getMessage ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+}
+
+public class io/matthewnelson/encoding/core/EncodingSizeException : io/matthewnelson/encoding/core/EncodingException {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
 public abstract interface annotation class io/matthewnelson/encoding/core/ExperimentalEncodingApi : java/lang/annotation/Annotation {
@@ -104,10 +110,17 @@ public abstract interface annotation class io/matthewnelson/encoding/core/intern
 public final class io/matthewnelson/encoding/core/util/DecoderInput {
 	public static final field Companion Lio/matthewnelson/encoding/core/util/DecoderInput$Companion;
 	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun decodeOutMaxSize ()I
 	public final fun get (I)C
+	public static final fun toDecoderInput (Ljava/lang/String;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
+	public static final fun toDecoderInput ([BLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
+	public static final fun toDecoderInput ([CLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 }
 
 public final class io/matthewnelson/encoding/core/util/DecoderInput$Companion {
+	public final fun toDecoderInput (Ljava/lang/String;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
+	public final fun toDecoderInput ([BLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
+	public final fun toDecoderInput ([CLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 }
 
 public final class io/matthewnelson/encoding/core/util/_ConversionsKt {

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -59,10 +59,10 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field isLenient Z
 	public final field paddingByte Ljava/lang/Byte;
 	public fun <init> (ZLjava/lang/Byte;)V
-	public final fun decodeOutMaxSizeOrFail (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
-	protected abstract fun decodeOutMaxSizeOrFailProtected (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
-	public final fun encodeOutSize (I)I
-	protected abstract fun encodeOutSizeProtected (I)I
+	public final fun decodeOutMaxSizeOrFail (JLio/matthewnelson/encoding/core/util/DecoderInput;)J
+	protected abstract fun decodeOutMaxSizeOrFailProtected (JLio/matthewnelson/encoding/core/util/DecoderInput;)J
+	public final fun encodeOutSize (J)J
+	protected abstract fun encodeOutSizeProtected (J)J
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public final fun toString ()Ljava/lang/String;

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/-Feed.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/-Feed.kt
@@ -35,8 +35,8 @@ internal inline fun Feed.closedException(): EncodingException {
  *  - Calling [Feed.close] if [block] **DID** throw an
  *    exception.
  *
- * @sample [io.matthewnelson.encoding.core.Encoder.encode]
- * @sample [io.matthewnelson.encoding.core.Decoder.decode]
+ * @sample [io.matthewnelson.encoding.core.internal.encode]
+ * @sample [io.matthewnelson.encoding.core.internal.decode]
  * */
 @ExperimentalEncodingApi
 @OptIn(ExperimentalContracts::class)

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -17,7 +17,7 @@
 
 package io.matthewnelson.encoding.core
 
-import io.matthewnelson.encoding.core.util.DecoderInput
+import io.matthewnelson.encoding.core.internal.decode
 import io.matthewnelson.encoding.core.util.DecoderInput.Companion.toDecoderInput
 import io.matthewnelson.encoding.core.util.byte
 import kotlin.jvm.JvmStatic
@@ -143,25 +143,6 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
                 decodeToArray(decoder)
             } catch (_: EncodingException) {
                 null
-            }
-        }
-
-        @Throws(EncodingException::class)
-        @OptIn(ExperimentalEncodingApi::class)
-        private fun Decoder.decode(input: DecoderInput, update: (Decoder.Feed) -> Unit): ByteArray {
-            val ba = ByteArray(input.decodeOutMaxSize)
-
-            var i = 0
-            newDecoderFeed { byte ->
-                ba[i++] = byte
-            }.use { feed ->
-                update.invoke(feed)
-            }
-
-            return if (i == input.decodeOutMaxSize) {
-                ba
-            } else {
-                ba.copyOf(i)
             }
         }
     }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -18,7 +18,7 @@
 package io.matthewnelson.encoding.core
 
 import io.matthewnelson.encoding.core.util.DecoderInput
-import io.matthewnelson.encoding.core.util.DecoderInput.Companion.toInputAnalysis
+import io.matthewnelson.encoding.core.util.DecoderInput.Companion.toDecoderInput
 import io.matthewnelson.encoding.core.util.byte
 import kotlin.jvm.JvmStatic
 
@@ -76,9 +76,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun String.decodeToArray(decoder: Decoder): ByteArray {
-            return decoder.decode(toInputAnalysis(decoder.config)) {
+            return decoder.decode(toDecoderInput(decoder.config)) { feed ->
                 forEach { char ->
-                    update(char.byte)
+                    feed.update(char.byte)
                 }
             }
         }
@@ -103,9 +103,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun CharArray.decodeToArray(decoder: Decoder): ByteArray {
-            return decoder.decode(toInputAnalysis(decoder.config)) {
+            return decoder.decode(toDecoderInput(decoder.config)) { feed ->
                 forEach { char ->
-                    update(char.byte)
+                    feed.update(char.byte)
                 }
             }
         }
@@ -130,9 +130,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun ByteArray.decodeToArray(decoder: Decoder): ByteArray {
-            return decoder.decode(toInputAnalysis(decoder.config)) {
+            return decoder.decode(toDecoderInput(decoder.config)) { feed ->
                 forEach { byte ->
-                    update(byte)
+                    feed.update(byte)
                 }
             }
         }
@@ -148,7 +148,7 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
 
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
-        private fun Decoder.decode(input: DecoderInput, update: Decoder.Feed.() -> Unit): ByteArray {
+        private fun Decoder.decode(input: DecoderInput, update: (Decoder.Feed) -> Unit): ByteArray {
             val ba = ByteArray(input.decodeOutMaxSize)
 
             var i = 0

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -69,8 +69,15 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
         /**
          * Encodes a [ByteArray] for the provided [encoder] and
          * returns the encoded data in the form of a [String].
+         *
+         * @throws [EncodingSizeException] if the encoded output
+         *   exceeds [Int.MAX_VALUE]. This is not applicable for
+         *   most encoding specifications as the majority compress
+         *   data, but is something that can occur with Base16
+         *   which produces 2 characters for every 1 byte of input.
          * */
         @JvmStatic
+        @Throws(EncodingSizeException::class)
         public fun ByteArray.encodeToString(encoder: Encoder): String {
             val sb = StringBuilder(encoder.config.encodeOutSize(size))
             encoder.encode(this) { byte ->
@@ -82,8 +89,15 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
         /**
          * Encodes a [ByteArray] for the provided [encoder] and
          * returns the encoded data in the form of a [CharArray].
+         *
+         * @throws [EncodingSizeException] if the encoded output
+         *   exceeds [Int.MAX_VALUE]. This is not applicable for
+         *   most encoding specifications as the majority compress
+         *   data, but is something that can occur with Base16
+         *   which produces 2 characters for every 1 byte of input.
          * */
         @JvmStatic
+        @Throws(EncodingSizeException::class)
         public fun ByteArray.encodeToCharArray(encoder: Encoder): CharArray {
             val ca = CharArray(encoder.config.encodeOutSize(size))
             var i = 0
@@ -96,8 +110,15 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
         /**
          * Encodes a [ByteArray] for the provided [encoder] and
          * returns the encoded data in the form of a [ByteArray].
+         *
+         * @throws [EncodingSizeException] if the encoded output
+         *   exceeds [Int.MAX_VALUE]. This is not applicable for
+         *   most encoding specifications as the majority compress
+         *   data, but is something that can occur with Base16
+         *   which produces 2 characters for every 1 byte of input.
          * */
         @JvmStatic
+        @Throws(EncodingSizeException::class)
         public fun ByteArray.encodeToByteArray(encoder: Encoder): ByteArray {
             val ba = ByteArray(encoder.config.encodeOutSize(size))
             var i = 0

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -75,19 +75,19 @@ constructor(config: Config): Encoder(config) {
          *   the size, or [unEncodedSize] was negative.
          * */
         @Throws(EncodingSizeException::class)
-        public fun encodeOutSize(unEncodedSize: Int): Int {
-            if (unEncodedSize < 0) {
+        public fun encodeOutSize(unEncodedSize: Long): Long {
+            if (unEncodedSize < 0L) {
                 throw EncodingSizeException("unEncodedSize cannot be negative")
             }
 
             // return early
-            if (unEncodedSize == 0) return 0
+            if (unEncodedSize == 0L) return 0L
 
-            val size = encodeOutSizeProtected(unEncodedSize)
-            if (size < 0) {
+            val outSize = encodeOutSizeProtected(unEncodedSize)
+            if (outSize < 0L) {
                 throw EncodingSizeException("Calculated size was negative")
             }
-            return size
+            return outSize
         }
 
         /**
@@ -108,32 +108,32 @@ constructor(config: Config): Encoder(config) {
          *   of [input] (if it has one) failed.
          * */
         @Throws(EncodingException::class)
-        public fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int {
-            if (encodedSize < 0) {
+        public fun decodeOutMaxSizeOrFail(encodedSize: Long, input: DecoderInput?): Long {
+            if (encodedSize < 0L) {
                 throw EncodingSizeException("encodedSize cannot be negative")
             }
 
             // return early
-            if (encodedSize == 0) return 0
+            if (encodedSize == 0L) return 0L
 
-            val maxSize = decodeOutMaxSizeOrFailProtected(encodedSize, input)
-            if (maxSize < 0) {
+            val outSize = decodeOutMaxSizeOrFailProtected(encodedSize, input)
+            if (outSize < 0L) {
                 throw EncodingSizeException("Calculated size was negative")
             }
-            return maxSize
+            return outSize
         }
 
         /**
          * Will only receive values greater than 0.
          * */
         @Throws(EncodingSizeException::class)
-        protected abstract fun encodeOutSizeProtected(unEncodedSize: Int): Int
+        protected abstract fun encodeOutSizeProtected(unEncodedSize: Long): Long
 
         /**
          * Will only receive values greater than 0.
          * */
         @Throws(EncodingException::class)
-        protected abstract fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput?): Int
+        protected abstract fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long
 
         /**
          * Will be called whenever [toString] is invoked, allowing

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -81,9 +81,12 @@ constructor(config: Config): Encoder(config) {
          * @param [encodedSize] size of the data being decoded.
          * @param [input] Provided for additional analysis in the event
          *   the decoding specification has checks to fail early.
+         * @throws [EncodingException] if implementation's check of [input]
+         *   failed (if it has one).
+         * @sample [io.matthewnelson.encoding.base32.Base32.Crockford.Config.decodeOutMaxSizeOrFail]
          * */
         @Throws(EncodingException::class)
-        public abstract fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput): Int
+        public abstract fun decodeOutMaxSizeOrFail(encodedSize: Int, input: DecoderInput?): Int
 
         protected abstract fun encodeOutSizeProtected(unEncodedSize: Int): Int
 

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -19,6 +19,7 @@ package io.matthewnelson.encoding.core
 
 import io.matthewnelson.encoding.core.util.DecoderInput
 import io.matthewnelson.encoding.core.util.char
+import io.matthewnelson.encoding.core.util.isSpaceOrNewLine
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
 
@@ -52,7 +53,7 @@ constructor(config: Config): Encoder(config) {
      * @param [isLenient] If true, decoding will skip over spaces
      *   and new lines ('\n', '\r', ' ', '\t'). If false, an
      *   [EncodingException] will be thrown when encountering those
-     *   characters.
+     *   characters. See [isSpaceOrNewLine].
      * @param [paddingByte] The byte used when padding the output for
      *   the given encoding; NOT "if padding should be
      *   used". (e.g. '='.code.toByte()).

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Exceptions.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Exceptions.kt
@@ -15,12 +15,17 @@
  **/
 package io.matthewnelson.encoding.core
 
-public class EncodingException: RuntimeException {
+public open class EncodingException: RuntimeException {
 
-    override val message: String
+    final override val message: String
 
     public constructor(message: String): this(message, null)
     public constructor(message: String, cause: Throwable?): super(message, cause) {
         this.message = message
     }
+}
+
+public open class EncodingSizeException: EncodingException {
+    public constructor(message: String): this(message, null)
+    public constructor(message: String, cause: Throwable?): super(message, cause)
 }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/EncoderDecoder.kt
@@ -55,7 +55,7 @@ internal inline fun <T: Any> Encoder.encodeOutSizeOrFail(
     val outSize = config.encodeOutSize(size.toLong())
     if (outSize > Int.MAX_VALUE.toLong()) {
         @OptIn(InternalEncodingApi::class)
-        throw DecoderInput.outSizeExceedsIntMaxEncodingException()
+        throw DecoderInput.outSizeExceedsMaxEncodingSizeException(outSize, Int.MAX_VALUE)
     }
 
     return block.invoke(outSize.toInt())

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/EncoderDecoder.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
+package io.matthewnelson.encoding.core.internal
+
+import io.matthewnelson.encoding.core.*
+import io.matthewnelson.encoding.core.EncoderDecoder.Config
+import io.matthewnelson.encoding.core.util.DecoderInput
+
+@Suppress("NOTHING_TO_INLINE")
+@Throws(EncodingException::class)
+@OptIn(ExperimentalEncodingApi::class)
+internal inline fun Decoder.decode(
+    input: DecoderInput,
+    update: (feed: Decoder.Feed) -> Unit
+): ByteArray {
+    val ba = ByteArray(input.decodeOutMaxSize)
+
+    var i = 0
+    newDecoderFeed { byte ->
+        ba[i++] = byte
+    }.use { feed ->
+        update.invoke(feed)
+    }
+
+    return if (i == input.decodeOutMaxSize) {
+        ba
+    } else {
+        ba.copyOf(i)
+    }
+}
+
+/**
+ * Fails if the returned [Long] for [Config.encodeOutSize]
+ * exceeds [Int.MAX_VALUE]
+ * */
+@Throws(EncodingSizeException::class)
+internal inline fun <T: Any> Encoder.encodeOutSizeOrFail(
+    size: Int, block: (outSize: Int) -> T
+): T {
+    val outSize = config.encodeOutSize(size.toLong())
+    if (outSize > Int.MAX_VALUE.toLong()) {
+        @OptIn(InternalEncodingApi::class)
+        throw DecoderInput.outSizeExceedsIntMaxEncodingException()
+    }
+
+    return block.invoke(outSize.toInt())
+}
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(ExperimentalEncodingApi::class)
+internal inline fun Encoder.encode(
+    bytes: ByteArray,
+    out: OutFeed,
+) {
+    if (bytes.isEmpty()) return
+
+    newEncoderFeed(out).use { feed ->
+        for (byte in bytes) {
+            feed.update(byte)
+        }
+    }
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/-Helpers.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/-Helpers.kt
@@ -17,6 +17,12 @@
 
 package io.matthewnelson.encoding.core.util
 
+/**
+ * Helper for checking if a character is a space or
+ * new line.
+ *
+ * @return true if the character matches '\n', '\r', ' ', or '\t'
+ * */
 @Suppress("NOTHING_TO_INLINE")
 public inline fun Char.isSpaceOrNewLine(): Boolean {
     return when(this) {

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -97,7 +97,7 @@ private constructor(
         val outSize = config.decodeOutMaxSizeOrFail(limit.toLong(), this)
 
         if (outSize > Int.MAX_VALUE.toLong()) {
-            throw outSizeExceedsIntMaxEncodingException()
+            throw outSizeExceedsMaxEncodingSizeException(limit, Int.MAX_VALUE)
         }
 
         _decodeOutMaxSize = outSize.toInt()
@@ -106,15 +106,18 @@ private constructor(
     public companion object {
 
         @JvmStatic
-        @InternalEncodingApi
+        @InternalEncodingApi // might move this somewhere else... don't use.
         public fun isLenientFalseEncodingException(): EncodingException {
             return EncodingException("Spaces and new lines are forbidden when isLenient[false]")
         }
 
         @JvmStatic
-        @InternalEncodingApi
-        public fun outSizeExceedsIntMaxEncodingException(): EncodingSizeException {
-            return EncodingSizeException("Size of encoded data would exceed the maximum value of ${Int.MAX_VALUE}")
+        @InternalEncodingApi // might move this somewhere else... don't use.
+        public fun outSizeExceedsMaxEncodingSizeException(
+            inSize: Number,
+            maxSize: Number,
+        ): EncodingSizeException {
+            return EncodingSizeException("Size[$inSize] of data would exceed the maximum[$maxSize] for this operation")
         }
 
         @JvmStatic

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -17,6 +17,7 @@ package io.matthewnelson.encoding.core.util
 
 import io.matthewnelson.encoding.core.EncoderDecoder
 import io.matthewnelson.encoding.core.EncodingException
+import io.matthewnelson.encoding.core.EncodingSizeException
 import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
@@ -93,7 +94,13 @@ private constructor(
             break
         }
 
-        _decodeOutMaxSize = config.decodeOutMaxSizeOrFail(limit, this)
+        val outSize = config.decodeOutMaxSizeOrFail(limit.toLong(), this)
+
+        if (outSize > Int.MAX_VALUE.toLong()) {
+            throw outSizeExceedsIntMaxEncodingException()
+        }
+
+        _decodeOutMaxSize = outSize.toInt()
     }
 
     public companion object {
@@ -102,6 +109,12 @@ private constructor(
         @InternalEncodingApi
         public fun isLenientFalseEncodingException(): EncodingException {
             return EncodingException("Spaces and new lines are forbidden when isLenient[false]")
+        }
+
+        @JvmStatic
+        @InternalEncodingApi
+        public fun outSizeExceedsIntMaxEncodingException(): EncodingSizeException {
+            return EncodingSizeException("Size of encoded data would exceed the maximum value of ${Int.MAX_VALUE}")
         }
 
         @JvmStatic

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -18,8 +18,8 @@ package io.matthewnelson.encoding.core.util
 import io.matthewnelson.encoding.core.EncoderDecoder
 import io.matthewnelson.encoding.core.EncodingException
 import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
-import kotlin.jvm.JvmSynthetic
 
 /**
  * Helper class for analyzing encoded data in order to
@@ -29,9 +29,10 @@ import kotlin.jvm.JvmSynthetic
  * Will "strip" padding (if the config specifies it) and
  * spaces/new lines from the end in order to provide
  * [EncoderDecoder.Config.decodeOutMaxSizeOrFail]
- * with the best guess at input size.
+ * with the best guess of the last relevant character.
  *
  * @see [get]
+ * @see [toDecoderInput]
  * @see [EncoderDecoder.Config.decodeOutMaxSizeOrFail]
  * */
 @OptIn(InternalEncodingApi::class)
@@ -42,8 +43,9 @@ private constructor(
     private val input: Any
 ) {
 
-    @get:JvmSynthetic
-    internal val decodeOutMaxSize: Int
+    private var _decodeOutMaxSize: Int = 0
+    @get:JvmName("decodeOutMaxSize")
+    public val decodeOutMaxSize: Int get() = _decodeOutMaxSize
 
     /**
      * Can be utilized by [EncoderDecoder.Config]
@@ -91,14 +93,7 @@ private constructor(
             break
         }
 
-        decodeOutMaxSize = if (limit == 0) {
-            0
-        } else {
-            // TODO: Decoder implementation could have an overflow
-            //  and return negative here. Must still check negative
-            //  and throw.
-            config.decodeOutMaxSizeOrFail(limit, this)
-        }
+        _decodeOutMaxSize = config.decodeOutMaxSizeOrFail(limit, this)
     }
 
     public companion object {
@@ -109,21 +104,21 @@ private constructor(
             return EncodingException("Spaces and new lines are forbidden when isLenient[false]")
         }
 
-        @JvmSynthetic
+        @JvmStatic
         @Throws(EncodingException::class)
-        internal fun String.toInputAnalysis(
+        public fun String.toDecoderInput(
             config: EncoderDecoder.Config
         ): DecoderInput = DecoderInput(config, this)
 
-        @JvmSynthetic
+        @JvmStatic
         @Throws(EncodingException::class)
-        internal fun CharArray.toInputAnalysis(
+        public fun CharArray.toDecoderInput(
             config: EncoderDecoder.Config
         ): DecoderInput = DecoderInput(config, this)
 
-        @JvmSynthetic
+        @JvmStatic
         @Throws(EncodingException::class)
-        internal fun ByteArray.toInputAnalysis(
+        public fun ByteArray.toDecoderInput(
             config: EncoderDecoder.Config
         ): DecoderInput = DecoderInput(config, this)
     }

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core
+
+import io.matthewnelson.encoding.core.helpers.TestConfig
+import kotlin.test.Test
+import kotlin.test.fail
+
+class EncoderDecoderConfigUnitTest {
+
+    @Test
+    fun givenConfig_whenNegativeValuesSent_thenThrowsEncodingSizeExceptionBeforePassingToProtected() {
+        val config = TestConfig(
+            encodeReturn = {
+                fail("Should not make it here")
+            },
+            decodeReturn = {
+                fail("Should not make it here")
+            }
+        )
+
+        try {
+            config.decodeOutMaxSizeOrFail(-1L, null)
+            fail()
+        } catch (_: EncodingSizeException) {
+            // pass
+        }
+
+        try {
+            config.encodeOutSize(-1L)
+            fail()
+        } catch (_: EncodingSizeException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun givenConfig_whenNegativeValuesReturned_thenThrowsEncodingSizeException() {
+        val config = TestConfig(
+            encodeReturn = { -1L },
+            decodeReturn = { -1L }
+        )
+
+        try {
+            config.decodeOutMaxSizeOrFail(5, null)
+            fail()
+        } catch (_: EncodingSizeException) {
+            // pass
+        }
+
+        try {
+            config.encodeOutSize(5)
+            fail()
+        } catch (_: EncodingSizeException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun givenConfig_whenPositiveValuesSentAndReturned_thenDoseNotThrowException() {
+        val config = TestConfig(
+            encodeReturn = { 1L },
+            decodeReturn = { 1L },
+        )
+
+        config.decodeOutMaxSizeOrFail(1L, null)
+        config.encodeOutSize(1L)
+    }
+
+    @Test
+    fun givenConfig_whenZeroPassed_thenReturns0Immediately() {
+        val config = TestConfig(
+            encodeReturn = { fail("Should not make it here") },
+            decodeReturn = { fail("Should not make it here") },
+        )
+
+        config.decodeOutMaxSizeOrFail(0L, null)
+        config.encodeOutSize(0L)
+    }
+
+    @Test
+    fun givenConfig_whenZeroReturned_thenDoesNotThrowException() {
+        val config = TestConfig(
+            encodeReturn = { 0L },
+            decodeReturn = { 0L },
+        )
+
+        config.decodeOutMaxSizeOrFail(1L, null)
+        config.encodeOutSize(1L)
+    }
+}

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestConfig.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestConfig.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core.helpers
+
+import io.matthewnelson.encoding.core.EncoderDecoder
+import io.matthewnelson.encoding.core.ExperimentalEncodingApi
+import io.matthewnelson.encoding.core.util.DecoderInput
+import io.matthewnelson.encoding.core.util.byte
+
+@OptIn(ExperimentalEncodingApi::class)
+class TestConfig(
+    isLenient: Boolean = false,
+    paddingByte: Byte? = '='.byte,
+    private val encodeReturn: (unEncodedSize: Long) -> Long = { -1L },
+    private val decodeReturn: (encodedSize: Long) -> Long = { -1L },
+): EncoderDecoder.Config(isLenient, paddingByte) {
+    override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+        return decodeReturn.invoke(encodedSize)
+    }
+    override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
+        return encodeReturn.invoke(unEncodedSize)
+    }
+    override fun toStringAddSettings(sb: StringBuilder) {}
+}

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/DecoderInputUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/DecoderInputUnitTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core.util
+
+import io.matthewnelson.encoding.core.EncodingException
+import io.matthewnelson.encoding.core.EncodingSizeException
+import io.matthewnelson.encoding.core.helpers.TestConfig
+import io.matthewnelson.encoding.core.util.DecoderInput.Companion.toDecoderInput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class DecoderInputUnitTest {
+
+    @Test
+    fun givenDecoderInput_whenPaddingPresent_thenFindsTheLastRelevantCharacter() {
+        val pad = '='
+        val encoded = "1234${pad}${pad}${pad}${pad}"
+        val expectedEncodedSize = 4L // just the stuff we care about
+        val expectedOutSize = 2L
+
+        val config = TestConfig(paddingByte = pad.byte) { encodedSize ->
+            assertEquals(expectedEncodedSize, encodedSize)
+            expectedOutSize // return
+        }
+
+        assertEquals(expectedOutSize.toInt(), encoded.toDecoderInput(config).decodeOutMaxSize)
+    }
+
+    @Test
+    fun givenDecoderInput_whenConfigIsLenientFalse_thenThrowsEncodingExceptionWhenSpaceOrNewLine() {
+        val valid = "VALID INPUT"
+
+        val config = TestConfig(isLenient = false) { validSize ->
+            assertEquals(valid.length.toLong(), validSize)
+            1 // return some positive value
+        }
+
+        // DecoderInput works from the end, so invalid
+        // characters must be at the end somewhere.
+        listOf(
+            "invalid\n",
+            "invalid\t",
+            "invalid\r",
+            "invalid ",
+            valid,
+        ).forEach { item ->
+            try {
+                item.toDecoderInput(config)
+                if (item != valid) {
+                    fail()
+                }
+            } catch (t: EncodingSizeException) {
+                fail("", t)
+            } catch (_: EncodingException) {
+                // pass
+            }
+        }
+    }
+
+    @Test
+    fun givenDecoderInput_whenConfigIsLenientTrue_thenPassesOverSpaceOrNewLine() {
+        val expected = 1L
+        val config = TestConfig(isLenient = true) { expected }
+
+        listOf(
+            "invalid\n",
+            "invalid\t",
+            "invalid\r",
+            "invalid ",
+        ).forEach { item ->
+            assertEquals(expected, item.toDecoderInput(config).decodeOutMaxSize.toLong())
+        }
+    }
+
+    @Test
+    fun givenDecoderInput_whenReturnedValueGreaterThanIntMax_thenThrowsEncodingSizeException() {
+        val config = TestConfig { Long.MAX_VALUE }
+
+        try {
+            "VALID".toDecoderInput(config)
+            fail()
+        } catch (_: EncodingSizeException) {
+            // pass
+        }
+    }
+}


### PR DESCRIPTION
Closes #48 

This PR:
 - Updates the input/output number types for `EncoderDecoder` pre-calculation methods from `Int` to `Long`
     - May be used when streaming data, not just decoding an `Array` or `String` which is limited to `Int.MAX_VALUE` 
 - Puts up guards in the base abstraction `EncoderDecoder.Config` so that only positive values are:
     - Passed to the implementations
     - Returned by the implementations
     - Will otherwise throw an `EncodingSizeException`
 - Adds unit tests for most things in the `encoding-core` module
     - Don't think it will change very much anymore, so.
 - Fixes the `Base32.Crockford.Config` calculation when `hyphenInterval` is set to something.
     - Actual tests for this will come later when implemented; things might move around still, so.
 - Cleans up some documentation
 - Cleans up some code