### PR TITLE
Rename `Decoder` extension functions

### DIFF
--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -19,7 +19,7 @@ package io.matthewnelson.component.encoding.base16
 
 import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.builders.Base16
-import io.matthewnelson.encoding.core.Decoder.Companion.decodeToArrayOrNull
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -36,12 +36,12 @@ internal val COMPATIBILITY: Base16 = Base16 {
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase16ToArray(): ByteArray? {
     @OptIn(InternalEncodingApi::class)
-    return decodeToArrayOrNull(COMPATIBILITY)
+    return decodeToByteArrayOrNull(COMPATIBILITY)
 }
 
 public fun CharArray.decodeBase16ToArray(): ByteArray? {
     @OptIn(InternalEncodingApi::class)
-    return decodeToArrayOrNull(COMPATIBILITY)
+    return decodeToByteArrayOrNull(COMPATIBILITY)
 }
 
 @Suppress("NOTHING_TO_INLINE")

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -46,7 +46,7 @@ import kotlin.jvm.JvmSynthetic
  *     val bytes = text.encodeToByteArray()
  *     val encoded = bytes.encodeToString(base16)
  *     println(encoded) // 48656C6C6F20576F726C6421
- *     val decoded = encoded.decodeToArray(base16).decodeToString()
+ *     val decoded = encoded.decodeToByteArray(base16).decodeToString()
  *     assertEquals(text, decoded)
  *
  * @see [io.matthewnelson.encoding.builders.Base16]

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -57,7 +57,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *     val bytes = text.encodeToByteArray()
      *     val encoded = bytes.encodeToString(base32Crockford)
      *     println(encoded) // 91JPR-V3F41-BPYWK-CCGGG~
-     *     val decoded = encoded.decodeToArray(base32Crockford).decodeToString()
+     *     val decoded = encoded.decodeToByteArray(base32Crockford).decodeToString()
      *     assertEquals(text, decoded)
      *
      * @see [Base32Crockford]
@@ -227,7 +227,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *     val bytes = text.encodeToByteArray()
      *     val encoded = bytes.encodeToString(base32Default)
      *     println(encoded) // JBSWY3DPEBLW64TMMQQQ====
-     *     val decoded = encoded.decodeToArray(base32Default).decodeToString()
+     *     val decoded = encoded.decodeToByteArray(base32Default).decodeToString()
      *     assertEquals(text, decoded)
      *
      * @see [Base32Default]
@@ -351,7 +351,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
      *     val bytes = text.encodeToByteArray()
      *     val encoded = bytes.encodeToString(base32Hex)
      *     println(encoded) // 91IMOR3F41BMUSJCCGGG====
-     *     val decoded = encoded.decodeToArray(base32Hex).decodeToString()
+     *     val decoded = encoded.decodeToByteArray(base32Hex).decodeToString()
      *     assertEquals(text, decoded)
      *
      * @see [Base32Hex]

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -1,23 +1,23 @@
 public abstract class io/matthewnelson/encoding/core/Decoder {
 	public static final field Companion Lio/matthewnelson/encoding/core/Decoder$Companion;
 	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun decodeToArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
-	public static final fun decodeToArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
-	public static final fun decodeToArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
-	public static final fun decodeToArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
-	public static final fun decodeToArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
-	public static final fun decodeToArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
 	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Config;
 	public abstract fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
 }
 
 public final class io/matthewnelson/encoding/core/Decoder$Companion {
-	public final fun decodeToArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
-	public final fun decodeToArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
-	public final fun decodeToArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
-	public final fun decodeToArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
-	public final fun decodeToArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
-	public final fun decodeToArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
 }
 
 public abstract class io/matthewnelson/encoding/core/Decoder$Feed : io/matthewnelson/encoding/core/EncoderDecoder$Feed {

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -1,10 +1,10 @@
 public abstract class io/matthewnelson/encoding/core/Decoder {
 	public static final field Companion Lio/matthewnelson/encoding/core/Decoder$Companion;
 	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun decodeToByteArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArray (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToByteArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToByteArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
-	public static final fun decodeToByteArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public static final fun decodeToByteArrayOrNull (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToByteArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public static final fun decodeToByteArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
 	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Config;
@@ -12,10 +12,10 @@ public abstract class io/matthewnelson/encoding/core/Decoder {
 }
 
 public final class io/matthewnelson/encoding/core/Decoder$Companion {
-	public final fun decodeToByteArray (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArray (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public final fun decodeToByteArray ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public final fun decodeToByteArray ([CLio/matthewnelson/encoding/core/Decoder;)[B
-	public final fun decodeToByteArrayOrNull (Ljava/lang/String;Lio/matthewnelson/encoding/core/Decoder;)[B
+	public final fun decodeToByteArrayOrNull (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/Decoder;)[B
 	public final fun decodeToByteArrayOrNull ([BLio/matthewnelson/encoding/core/Decoder;)[B
 	public final fun decodeToByteArrayOrNull ([CLio/matthewnelson/encoding/core/Decoder;)[B
 }
@@ -112,13 +112,13 @@ public final class io/matthewnelson/encoding/core/util/DecoderInput {
 	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun decodeOutMaxSize ()I
 	public final fun get (I)C
-	public static final fun toDecoderInput (Ljava/lang/String;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
+	public static final fun toDecoderInput (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 	public static final fun toDecoderInput ([BLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 	public static final fun toDecoderInput ([CLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 }
 
 public final class io/matthewnelson/encoding/core/util/DecoderInput$Companion {
-	public final fun toDecoderInput (Ljava/lang/String;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
+	public final fun toDecoderInput (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 	public final fun toDecoderInput ([BLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 	public final fun toDecoderInput ([CLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -75,7 +75,7 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @JvmStatic
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
-        public fun String.decodeToByteArray(decoder: Decoder): ByteArray {
+        public fun CharSequence.decodeToByteArray(decoder: Decoder): ByteArray {
             return decoder.decode(toDecoderInput(decoder.config)) { feed ->
                 forEach { char ->
                     feed.update(char.byte)
@@ -84,7 +84,7 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         }
 
         @JvmStatic
-        public fun String.decodeToByteArrayOrNull(decoder: Decoder): ByteArray? {
+        public fun CharSequence.decodeToByteArrayOrNull(decoder: Decoder): ByteArray? {
             return try {
                 decodeToByteArray(decoder)
             } catch (_: EncodingException) {

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -26,8 +26,8 @@ import kotlin.jvm.JvmStatic
  * Decode things.
  *
  * @see [EncoderDecoder]
- * @see [decodeToArray]
- * @see [decodeToArrayOrNull]
+ * @see [decodeToByteArray]
+ * @see [decodeToByteArrayOrNull]
  * @see [Feed]
  * @see [newDecoderFeed]
  * */
@@ -69,13 +69,13 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
          * Decodes a [String] for the provided [decoder] and
          * returns the decoded bytes.
          *
-         * @see [decodeToArrayOrNull]
+         * @see [decodeToByteArrayOrNull]
          * @throws [EncodingException] if decoding failed.
          * */
         @JvmStatic
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
-        public fun String.decodeToArray(decoder: Decoder): ByteArray {
+        public fun String.decodeToByteArray(decoder: Decoder): ByteArray {
             return decoder.decode(toDecoderInput(decoder.config)) { feed ->
                 forEach { char ->
                     feed.update(char.byte)
@@ -84,9 +84,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         }
 
         @JvmStatic
-        public fun String.decodeToArrayOrNull(decoder: Decoder): ByteArray? {
+        public fun String.decodeToByteArrayOrNull(decoder: Decoder): ByteArray? {
             return try {
-                decodeToArray(decoder)
+                decodeToByteArray(decoder)
             } catch (_: EncodingException) {
                 null
             }
@@ -96,13 +96,13 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
          * Decodes a [CharArray] for the provided [decoder] and
          * returns the decoded bytes.
          *
-         * @see [decodeToArrayOrNull]
+         * @see [decodeToByteArrayOrNull]
          * @throws [EncodingException] if decoding failed.
          * */
         @JvmStatic
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
-        public fun CharArray.decodeToArray(decoder: Decoder): ByteArray {
+        public fun CharArray.decodeToByteArray(decoder: Decoder): ByteArray {
             return decoder.decode(toDecoderInput(decoder.config)) { feed ->
                 forEach { char ->
                     feed.update(char.byte)
@@ -111,9 +111,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         }
 
         @JvmStatic
-        public fun CharArray.decodeToArrayOrNull(decoder: Decoder): ByteArray? {
+        public fun CharArray.decodeToByteArrayOrNull(decoder: Decoder): ByteArray? {
             return try {
-                decodeToArray(decoder)
+                decodeToByteArray(decoder)
             } catch (_: EncodingException) {
                 null
             }
@@ -123,13 +123,13 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
          * Decodes a [ByteArray] for the provided [decoder] and
          * returns the decoded bytes.
          *
-         * @see [decodeToArrayOrNull]
+         * @see [decodeToByteArrayOrNull]
          * @throws [EncodingException] if decoding failed.
          * */
         @JvmStatic
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
-        public fun ByteArray.decodeToArray(decoder: Decoder): ByteArray {
+        public fun ByteArray.decodeToByteArray(decoder: Decoder): ByteArray {
             return decoder.decode(toDecoderInput(decoder.config)) { feed ->
                 forEach { byte ->
                     feed.update(byte)
@@ -138,9 +138,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         }
 
         @JvmStatic
-        public fun ByteArray.decodeToArrayOrNull(decoder: Decoder): ByteArray? {
+        public fun ByteArray.decodeToByteArrayOrNull(decoder: Decoder): ByteArray? {
             return try {
-                decodeToArray(decoder)
+                decodeToByteArray(decoder)
             } catch (_: EncodingException) {
                 null
             }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/DecoderInput.kt
@@ -57,7 +57,7 @@ private constructor(
     public operator fun get(index: Int): Char {
         return try {
             when (input) {
-                is String -> input[index]
+                is CharSequence -> input[index]
                 is CharArray -> input[index]
                 else -> (input as ByteArray)[index].char
             }
@@ -68,7 +68,7 @@ private constructor(
 
     init {
         var limit = when (input) {
-            is String -> input.length
+            is CharSequence -> input.length
             is CharArray -> input.size
             else -> (input as ByteArray).size
         }
@@ -122,7 +122,7 @@ private constructor(
 
         @JvmStatic
         @Throws(EncodingException::class)
-        public fun String.toDecoderInput(
+        public fun CharSequence.toDecoderInput(
             config: EncoderDecoder.Config
         ): DecoderInput = DecoderInput(config, this)
 

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/DecoderInputUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/DecoderInputUnitTest.kt
@@ -97,4 +97,45 @@ class DecoderInputUnitTest {
             // pass
         }
     }
+
+    @Test
+    fun givenDecoderInput_whenInputIsCharSequence_thenSuccess() {
+        // Include spaces and set isLenient = true (so they are
+        // skipped) in order to exercise DecoderInput.get
+        val validInput = "D    " as CharSequence
+        val config = TestConfig(isLenient = true) { inputSize ->
+            assertEquals(1L, inputSize)
+            inputSize// pass
+        }
+
+        validInput.toDecoderInput(config)
+    }
+
+    @Test
+    fun givenDecoderInput_whenInputIsCharArray_thenSuccess() {
+        // Include spaces and set isLenient = true (so they are
+        // skipped) in order to exercise DecoderInput.get
+        val validInput = CharArray(5) { ' ' }.apply { set(0, 'D') }
+        val config = TestConfig(isLenient = true) { inputSize ->
+            assertEquals(1L, inputSize)
+            inputSize
+        }
+
+        validInput.toDecoderInput(config)
+    }
+
+    @Test
+    fun givenDecoderInput_whenInputIsByteArray_thenSuccess() {
+        // Include spaces and set isLenient = true (so they are
+        // skipped) in order to exercise DecoderInput.get
+        val validInput = ByteArray(5) { ' '.byte }.apply { set(0, 'D'.byte) }
+        val config = TestConfig(isLenient = true) { inputSize ->
+            assertEquals(1L, inputSize)
+            inputSize
+        }
+
+        validInput.toDecoderInput(config)
+    }
+
+
 }


### PR DESCRIPTION
Closes #50 

This PR:
 - Renames functions from `decodeToArray` -> `decodeToByteArray`
 - Changes the extension function type from `String` to `CharSequence`
     - Adds tests to ensure `DecoderInput` is exercised thoroughly for each type.