### PR TITLE
Implement `Base64` encoding/decoding with new `EncoderDecoder`

### DIFF
--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -118,6 +118,7 @@ public class Base16(config: Config): EncoderDecoder(config) {
         private val TABLE_LOWERCASE = EncodingTable.from(CHARS.lowercase())
     }
 
+    @ExperimentalEncodingApi
     override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
         return object : Encoder.Feed() {
 
@@ -137,6 +138,7 @@ public class Base16(config: Config): EncoderDecoder(config) {
         }
     }
 
+    @ExperimentalEncodingApi
     override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
         return object : Decoder.Feed() {
 

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -195,6 +195,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             private val TABLE_LOWERCASE = EncodingTable.from(CHARS.lowercase())
         }
 
+        @ExperimentalEncodingApi
         override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
             return object : Decoder.Feed() {
 
@@ -302,6 +303,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             }
         }
 
+        @ExperimentalEncodingApi
         override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
             return object : Encoder.Feed() {
 
@@ -447,6 +449,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             private val TABLE_LOWERCASE = EncodingTable.from(CHARS.lowercase())
         }
 
+        @ExperimentalEncodingApi
         override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
             return object : Decoder.Feed() {
 
@@ -488,6 +491,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             }
         }
 
+        @ExperimentalEncodingApi
         override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
             return object : Encoder.Feed() {
 
@@ -610,6 +614,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             private val TABLE_LOWERCASE = EncodingTable.from(CHARS.lowercase())
         }
 
+        @ExperimentalEncodingApi
         override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
             return object : Decoder.Feed() {
 
@@ -651,6 +656,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             }
         }
 
+        @ExperimentalEncodingApi
         override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
             return object : Encoder.Feed() {
 

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -706,61 +706,61 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             out.invoke(table[(buffer shr 20 and 0x1fL).toInt()]) // 40-4*5 = 20
             out.invoke(table[(buffer shr 15 and 0x1fL).toInt()]) // 40-5*5 = 15
             out.invoke(table[(buffer shr 10 and 0x1fL).toInt()]) // 40-6*5 = 10
-            out.invoke(table[(buffer shr  5 and 0x1fL).toInt()]) // 40-7*5 = 5
-            out.invoke(table[(buffer        and 0x1fL).toInt()]) // 40-8*5 = 0
+            out.invoke(table[(buffer shr  5 and 0x1fL).toInt()]) // 40-7*5 =  5
+            out.invoke(table[(buffer        and 0x1fL).toInt()]) // 40-8*5 =  0
         },
         finalize = { count, blockSize, buf, byteBuffer ->
-            var bitBuffer = buf
+            var buffer = buf
 
             val padCount: Int = when (count % blockSize) {
                 0 -> { 0 }
                 1 -> {
                     // 8*1 = 8 bits
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[0].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[0].toBits()
 
-                    out.invoke(table[(bitBuffer shr 3 and 0x1fL).toInt()]) // 8-1*5 = 3
-                    out.invoke(table[(bitBuffer shl 2 and 0x1fL).toInt()]) // 5-3 = 2
+                    out.invoke(table[(buffer shr  3 and 0x1fL).toInt()]) // 8-1*5 = 3
+                    out.invoke(table[(buffer shl  2 and 0x1fL).toInt()]) // 5-3 = 2
                     6
                 }
                 2 -> {
                     // 8*2 = 16 bits
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[0].toBits()
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[1].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[0].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[1].toBits()
 
-                    out.invoke(table[(bitBuffer shr 11 and 0x1fL).toInt()]) // 16-1*5 = 11
-                    out.invoke(table[(bitBuffer shr  6 and 0x1fL).toInt()]) // 16-2*5 = 6
-                    out.invoke(table[(bitBuffer shr  1 and 0x1fL).toInt()]) // 16-3*5 = 1
-                    out.invoke(table[(bitBuffer shl  4 and 0x1fL).toInt()]) // 5-1 = 4
+                    out.invoke(table[(buffer shr 11 and 0x1fL).toInt()]) // 16-1*5 = 11
+                    out.invoke(table[(buffer shr  6 and 0x1fL).toInt()]) // 16-2*5 = 6
+                    out.invoke(table[(buffer shr  1 and 0x1fL).toInt()]) // 16-3*5 = 1
+                    out.invoke(table[(buffer shl  4 and 0x1fL).toInt()]) // 5-1 = 4
                     4
                 }
                 3 -> {
                     // 8*3 = 24 bits
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[0].toBits()
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[1].toBits()
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[2].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[0].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[1].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[2].toBits()
 
-                    out.invoke(table[(bitBuffer shr 19 and 0x1fL).toInt()]) // 24-1*5 = 19
-                    out.invoke(table[(bitBuffer shr 14 and 0x1fL).toInt()]) // 24-2*5 = 14
-                    out.invoke(table[(bitBuffer shr  9 and 0x1fL).toInt()]) // 24-3*5 = 9
-                    out.invoke(table[(bitBuffer shr  4 and 0x1fL).toInt()]) // 24-4*5 = 4
-                    out.invoke(table[(bitBuffer shl  1 and 0x1fL).toInt()]) // 5-4 = 1
+                    out.invoke(table[(buffer shr 19 and 0x1fL).toInt()]) // 24-1*5 = 19
+                    out.invoke(table[(buffer shr 14 and 0x1fL).toInt()]) // 24-2*5 = 14
+                    out.invoke(table[(buffer shr  9 and 0x1fL).toInt()]) // 24-3*5 = 9
+                    out.invoke(table[(buffer shr  4 and 0x1fL).toInt()]) // 24-4*5 = 4
+                    out.invoke(table[(buffer shl  1 and 0x1fL).toInt()]) // 5-4 = 1
                     3
                 }
                 // 4
                 else -> {
                     // 8*4 = 32 bits
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[0].toBits()
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[1].toBits()
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[2].toBits()
-                    bitBuffer = (bitBuffer shl 8) + byteBuffer[3].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[0].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[1].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[2].toBits()
+                    buffer =         (buffer shl  8) + byteBuffer[3].toBits()
 
-                    out.invoke(table[(bitBuffer shr 27 and 0x1fL).toInt()]) // 32-1*5 = 27
-                    out.invoke(table[(bitBuffer shr 22 and 0x1fL).toInt()]) // 32-2*5 = 22
-                    out.invoke(table[(bitBuffer shr 17 and 0x1fL).toInt()]) // 32-3*5 = 17
-                    out.invoke(table[(bitBuffer shr 12 and 0x1fL).toInt()]) // 32-4*5 = 12
-                    out.invoke(table[(bitBuffer shr  7 and 0x1fL).toInt()]) // 32-5*5 = 7
-                    out.invoke(table[(bitBuffer shr  2 and 0x1fL).toInt()]) // 32-6*5 = 2
-                    out.invoke(table[(bitBuffer shl  3 and 0x1fL).toInt()]) // 5-2 = 3
+                    out.invoke(table[(buffer shr 27 and 0x1fL).toInt()]) // 32-1*5 = 27
+                    out.invoke(table[(buffer shr 22 and 0x1fL).toInt()]) // 32-2*5 = 22
+                    out.invoke(table[(buffer shr 17 and 0x1fL).toInt()]) // 32-3*5 = 17
+                    out.invoke(table[(buffer shr 12 and 0x1fL).toInt()]) // 32-4*5 = 12
+                    out.invoke(table[(buffer shr  7 and 0x1fL).toInt()]) // 32-5*5 = 7
+                    out.invoke(table[(buffer shr  2 and 0x1fL).toInt()]) // 32-6*5 = 2
+                    out.invoke(table[(buffer shl  3 and 0x1fL).toInt()]) // 5-2 = 3
                     1
                 }
             }

--- a/library/encoding-base64/api/encoding-base64.api
+++ b/library/encoding-base64/api/encoding-base64.api
@@ -38,3 +38,43 @@ public final class io/matthewnelson/component/base64/Base64Kt {
 	public static synthetic fun encodeBase64ToCharArray$default ([BLio/matthewnelson/component/base64/Base64;ILjava/lang/Object;)[C
 }
 
+public final class io/matthewnelson/encoding/base64/Base64 : io/matthewnelson/encoding/core/EncoderDecoder {
+	public fun <init> (Lio/matthewnelson/encoding/base64/Base64$Config;)V
+	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
+	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+}
+
+public final class io/matthewnelson/encoding/base64/Base64$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
+	public final field encodeToUrlSafe Z
+	public final field padEncoded Z
+	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/matthewnelson/encoding/base64/Base64$Default {
+	public static final field CHARS Ljava/lang/String;
+	public static final field INSTANCE Lio/matthewnelson/encoding/base64/Base64$Default;
+}
+
+public final class io/matthewnelson/encoding/base64/Base64$UrlSafe {
+	public static final field CHARS Ljava/lang/String;
+	public static final field INSTANCE Lio/matthewnelson/encoding/base64/Base64$UrlSafe;
+}
+
+public final class io/matthewnelson/encoding/builders/Base64BuildersKt {
+	public static final fun Base64 ()Lio/matthewnelson/encoding/base64/Base64;
+	public static final fun Base64 (Lio/matthewnelson/encoding/base64/Base64$Config;Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base64/Base64;
+	public static final fun Base64 (Lkotlin/jvm/functions/Function1;)Lio/matthewnelson/encoding/base64/Base64;
+	public static final fun Base64 (Z)Lio/matthewnelson/encoding/base64/Base64;
+	public static synthetic fun Base64$default (ZILjava/lang/Object;)Lio/matthewnelson/encoding/base64/Base64;
+}
+
+public final class io/matthewnelson/encoding/builders/Base64ConfigBuilder {
+	public field encodeToUrlSafe Z
+	public field isLenient Z
+	public field padEncoded Z
+	public fun <init> ()V
+	public fun <init> (Lio/matthewnelson/encoding/base64/Base64$Config;)V
+	public final fun build ()Lio/matthewnelson/encoding/base64/Base64$Config;
+	public final fun strict ()Lio/matthewnelson/encoding/builders/Base64ConfigBuilder;
+}
+

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("RemoveRedundantQualifierName", "SpellCheckingInspection")
+
+package io.matthewnelson.encoding.base64
+
+import io.matthewnelson.encoding.base64.Base64.Default
+import io.matthewnelson.encoding.builders.Base64ConfigBuilder
+import io.matthewnelson.encoding.core.*
+import io.matthewnelson.encoding.core.internal.EncodingTable
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+import io.matthewnelson.encoding.core.util.DecoderInput
+import io.matthewnelson.encoding.core.util.buffer.DecodingBuffer
+import io.matthewnelson.encoding.core.util.buffer.EncodingBuffer
+import io.matthewnelson.encoding.core.util.byte
+import io.matthewnelson.encoding.core.util.char
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Base 64 encoding/decoding in accordance with
+ * RFC 4648 section 4 & 5 (Default & UrlSafe)
+ *
+ * https://www.ietf.org/rfc/rfc4648.html#section-4
+ * https://www.ietf.org/rfc/rfc4648.html#section-5
+ *
+ * Decodes both Default and UrlSafe, while encoding
+ * to UrlSafe can be configured via the [Base64.Config].
+ *
+ * e.g.
+ *
+ *     val base64 = Base64 {
+ *         isLenient = true
+ *         encodeToUrlSafe = false
+ *         padEncoded = true
+ *     }
+ *
+ *     val text = "Hello World!"
+ *     val bytes = text.encodeToByteArray()
+ *     val encoded = bytes.encodeToString(base64)
+ *     println(encoded) // SGVsbG8gV29ybGQh
+ *     val decoded = encoded.decodeToByteArray(base64).decodeToString()
+ *     assertEquals(text, decoded)
+ *
+ * @see [io.matthewnelson.encoding.builders.Base64]
+ * @see [Base64.Config]
+ * @see [Default.CHARS]
+ * @see [UrlSafe.CHARS]
+ * @see [EncoderDecoder]
+ * */
+@OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
+public class Base64(config: Base64.Config): EncoderDecoder(config) {
+
+    /**
+     * Configuration for [Base64] encoding/decoding.
+     *
+     * Use [Base64ConfigBuilder] to create.
+     *
+     * @see [Base64ConfigBuilder]
+     * @see [EncoderDecoder.Config]
+     * */
+    public class Config private constructor(
+        isLenient: Boolean,
+        @JvmField
+        public val encodeToUrlSafe: Boolean,
+        @JvmField
+        public val padEncoded: Boolean,
+    ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
+
+        @Throws(EncodingException::class)
+        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+            return (encodedSize * 6L / 8L)
+        }
+
+        override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
+            var outSize: Long = (unEncodedSize + 2L) / 3L * 4L
+            if (padEncoded) return outSize
+
+            when (unEncodedSize - (unEncodedSize - unEncodedSize % 3)) {
+                0L -> { /* no-op */ }
+                1L -> outSize -= 2L
+                2L -> outSize -= 1L
+            }
+
+            return outSize
+        }
+
+        override fun toStringAddSettings(sb: StringBuilder) {
+            with(sb) {
+                append("    encodeToUrlSafe: ")
+                append(encodeToUrlSafe)
+                appendLine()
+                append("    padEncoded: ")
+                append(padEncoded)
+            }
+        }
+
+        internal companion object {
+
+            @JvmSynthetic
+            internal fun from(builder: Base64ConfigBuilder): Config {
+                return Config(
+                    isLenient = builder.isLenient,
+                    encodeToUrlSafe = builder.encodeToUrlSafe,
+                    padEncoded = builder.padEncoded,
+                )
+            }
+        }
+    }
+
+    public object Default {
+
+        /**
+         * Base64 Default encoding characters.
+         * */
+        public const val CHARS: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    }
+
+    public object UrlSafe {
+
+        /**
+         * Base64 UrlSafe encoding characters.
+         * */
+        public const val CHARS: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    }
+
+    @ExperimentalEncodingApi
+    override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
+        return object : Decoder.Feed() {
+
+            private val buffer = Base64DecodingBuffer(out)
+
+            override fun updateProtected(input: Byte) {
+                val bits: Int = when (val c = input.char) {
+                    in '0'..'9' -> {
+                        // char ASCII value
+                        //  0    48    52
+                        //  9    57    61 (ASCII + 4)
+                        c.code + 4
+                    }
+                    in 'A'..'Z' -> {
+                        // char ASCII value
+                        //  A    65    0
+                        //  Z    90    25 (ASCII - 65)
+                        c.code - 65
+                    }
+                    in 'a'..'z' -> {
+                        // char ASCII value
+                        //  a    97    26
+                        //  z    122   51 (ASCII - 71)
+                        c.code - 71
+                    }
+                    '+', '-' -> {
+                        62
+                    }
+                    '/', '_' -> {
+                        63
+                    }
+                    else -> {
+                        throw EncodingException("Char[$c] is not a valid Base64 character")
+                    }
+                }
+
+                buffer.update(bits)
+            }
+
+            override fun doFinalProtected() {
+                buffer.finalize()
+            }
+        }
+    }
+
+    @ExperimentalEncodingApi
+    override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
+        return object : Encoder.Feed() {
+
+            private val buffer = Base64EncodingBuffer(
+                out = out,
+                table = if ((config as Base64.Config).encodeToUrlSafe) {
+                    TABLE_URL_SAFE
+                } else {
+                    TABLE_DEFAULT
+                },
+                paddingByte = if ((config as Base64.Config).padEncoded) {
+                    config.paddingByte
+                } else {
+                    null
+                },
+            )
+
+            override fun updateProtected(input: Byte) {
+                buffer.update(input)
+            }
+
+            override fun doFinalProtected() {
+                buffer.finalize()
+            }
+        }
+    }
+
+    override fun name(): String = "Base64"
+
+    private inner class Base64DecodingBuffer(out: OutFeed): DecodingBuffer(
+        blockSize = 4,
+        flush = { buffer ->
+            // Append this char's 6 bits to the word.
+            var bitBuffer = 0
+            for (bits in buffer) {
+                bitBuffer = bitBuffer shl 6 or bits
+            }
+
+            // For every 4 chars of input, we accumulate 24 bits of output. Emit 3 bytes.
+            out.invoke((bitBuffer shr 16).toByte())
+            out.invoke((bitBuffer shr  8).toByte())
+            out.invoke((bitBuffer       ).toByte())
+        },
+        finalize = { modulus, buffer ->
+            if (modulus == 1) {
+                // We read 1 char followed by "===". But 6 bits is a truncated byte! Fail.
+                throw truncatedInputEncodingException(modulus)
+            }
+
+            var bitBuffer = 0
+            for (i in 0 until modulus) {
+                bitBuffer = bitBuffer shl 6 or buffer[i]
+            }
+
+            when (modulus) {
+                2 -> {
+                    // We read 2 chars followed by "==". Emit 1 byte with 8 of those 12 bits.
+                    bitBuffer = bitBuffer shl 12
+                    out.invoke((bitBuffer shr 16).toByte())
+                }
+                3 -> {
+                    // We read 3 chars, followed by "=". Emit 2 bytes for 16 of those 18 bits.
+                    bitBuffer = bitBuffer shl  6
+                    out.invoke((bitBuffer shr 16).toByte())
+                    out.invoke((bitBuffer shr  8).toByte())
+                }
+            }
+        },
+    )
+
+    private inner class Base64EncodingBuffer(
+        out: OutFeed,
+        table: EncodingTable,
+        paddingByte: Byte?,
+    ): EncodingBuffer(
+        blockSize = 3,
+        flush = { buffer ->
+            // For every 3 chars of input, we accumulate
+            // 24 bits of output. Emit 4 bytes.
+            val b0 = buffer[0].toInt()
+            val b1 = buffer[1].toInt()
+            val b2 = buffer[2].toInt()
+            out.invoke(table[(b0 and 0xff shr 2)])
+            out.invoke(table[(b0 and 0x03 shl 4) or (b1 and 0xff shr 4)])
+            out.invoke(table[(b1 and 0x0f shl 2) or (b2 and 0xff shr 6)])
+            out.invoke(table[(b2 and 0x3f)])
+        },
+        finalize = { modulus, buffer ->
+            val padCount: Int = when (modulus) {
+                0 -> { 0 }
+                1 -> {
+                    val b0 = buffer[0].toInt()
+                    out.invoke(table[b0 and 0xff shr 2])
+                    out.invoke(table[b0 and 0x03 shl 4])
+                    2
+                }
+                // 2
+                else -> {
+                    val b0 = buffer[0].toInt()
+                    val b1 = buffer[1].toInt()
+                    out.invoke(table[(b0 and 0xff shr 2)])
+                    out.invoke(table[(b0 and 0x03 shl 4) or (b1 and 0xff shr 4)])
+                    out.invoke(table[(b1 and 0x0f shl 2)])
+                    1
+                }
+            }
+
+            paddingByte?.let { byte ->
+                repeat(padCount) {
+                    out.invoke(byte)
+                }
+            }
+        }
+    )
+
+    private companion object {
+        private val TABLE_DEFAULT = EncodingTable.from(Default.CHARS)
+        private val TABLE_URL_SAFE = EncodingTable.from(UrlSafe.CHARS)
+    }
+}

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -31,7 +31,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmSynthetic
 
 /**
- * Base 64 encoding/decoding in accordance with
+ * Base64 encoding/decoding in accordance with
  * RFC 4648 section 4 & 5 (Default & UrlSafe)
  *
  * https://www.ietf.org/rfc/rfc4648.html#section-4
@@ -216,7 +216,7 @@ public class Base64(config: Base64.Config): EncoderDecoder(config) {
     private inner class Base64DecodingBuffer(out: OutFeed): DecodingBuffer(
         blockSize = 4,
         flush = { buffer ->
-            // Append this char's 6 bits to the word.
+            // Append each char's 6 bits to the buffer.
             var bitBuffer = 0
             for (bits in buffer) {
                 bitBuffer = bitBuffer shl 6 or bits

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.builders
+
+import io.matthewnelson.encoding.base64.Base64
+import io.matthewnelson.encoding.core.EncodingException
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmOverloads
+
+/**
+ * Creates a configured [Base64] encoder/decoder.
+ *
+ * @param [config] inherit settings from.
+ * @see [Base64ConfigBuilder]
+ * */
+public fun Base64(
+    config: Base64.Config?,
+    block: Base64ConfigBuilder.() -> Unit,
+): Base64 {
+    val builder = Base64ConfigBuilder(config)
+    block.invoke(builder)
+    return Base64(builder.build())
+}
+
+/**
+ * Creates a configured [Base64] encoder/decoder.
+ *
+ * @see [Base64ConfigBuilder]
+ * */
+public fun Base64(
+    block: Base64ConfigBuilder.() -> Unit,
+): Base64 {
+    return Base64(null, block)
+}
+
+/**
+ * Creates a configured [Base64] encoder/decoder
+ * using the default settings.
+ *
+ * @param [strict] If true, configures the encoder/decoder
+ *   to be in strict accordance with RFC 4648.
+ * @see [Base64ConfigBuilder]
+ * */
+@JvmOverloads
+public fun Base64(strict: Boolean = false): Base64 = Base64 { if (strict) strict() }
+
+/**
+ * Builder for creating a [Base64.Config].
+ *
+ * @see [strict]
+ * @see [io.matthewnelson.encoding.builders.Base64]
+ * */
+public class Base64ConfigBuilder {
+
+    public constructor()
+    public constructor(config: Base64.Config?): this() {
+        if (config == null) return
+        isLenient = config.isLenient ?: true
+        encodeToUrlSafe = config.encodeToUrlSafe
+        padEncoded = config.padEncoded
+    }
+
+    /**
+     * If true, spaces and new lines ('\n', '\r', ' ', '\t')
+     * will be skipped over when decoding (against RFC 4648).
+     *
+     * If false, an [EncodingException] will be thrown if
+     * those characters are encountered when decoding.
+     * */
+    @JvmField
+    public var isLenient: Boolean = true
+
+    /**
+     * If true, will output Base64 UrlSafe characters
+     * when encoding.
+     *
+     * If false, will output Base64 Default characters
+     * when encoding.
+     * */
+    @JvmField
+    public var encodeToUrlSafe: Boolean = false
+
+    /**
+     * If true, padding **WILL** be applied to the encoded
+     * output.
+     *
+     * If false, padding **WILL NOT** be applied to the
+     * encoded output (against RFC 4648).
+     * */
+    @JvmField
+    public var padEncoded: Boolean = true
+
+    /**
+     * A shortcut for configuring things to be in strict
+     * adherence with RFC 4648.
+     * */
+    public fun strict(): Base64ConfigBuilder {
+        isLenient = false
+        padEncoded = true
+        return this
+    }
+
+    public fun build(): Base64.Config = Base64.Config.from(this)
+}

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -183,3 +183,43 @@ public final class io/matthewnelson/encoding/core/util/_ConversionsKt {
 	public static final fun getChar (B)C
 }
 
+public abstract class io/matthewnelson/encoding/core/util/buffer/DecodingBuffer : io/matthewnelson/encoding/core/util/buffer/FeedBuffer {
+	public fun <init> (ILio/matthewnelson/encoding/core/util/buffer/FeedBuffer$Flush;Lio/matthewnelson/encoding/core/util/buffer/FeedBuffer$Finalize;)V
+	protected final fun buffer (Lio/matthewnelson/encoding/core/internal/Internal;)[Ljava/lang/Integer;
+	public synthetic fun buffer (Lio/matthewnelson/encoding/core/internal/Internal;)[Ljava/lang/Number;
+	protected final fun zero ()Ljava/lang/Integer;
+	public synthetic fun zero ()Ljava/lang/Number;
+}
+
+public abstract class io/matthewnelson/encoding/core/util/buffer/EncodingBuffer : io/matthewnelson/encoding/core/util/buffer/FeedBuffer {
+	public fun <init> (ILio/matthewnelson/encoding/core/util/buffer/FeedBuffer$Flush;Lio/matthewnelson/encoding/core/util/buffer/FeedBuffer$Finalize;)V
+	protected final fun buffer (Lio/matthewnelson/encoding/core/internal/Internal;)[Ljava/lang/Byte;
+	public synthetic fun buffer (Lio/matthewnelson/encoding/core/internal/Internal;)[Ljava/lang/Number;
+	protected final fun zero ()Ljava/lang/Byte;
+	public synthetic fun zero ()Ljava/lang/Number;
+}
+
+public abstract class io/matthewnelson/encoding/core/util/buffer/FeedBuffer {
+	public static final field Companion Lio/matthewnelson/encoding/core/util/buffer/FeedBuffer$Companion;
+	public final field blockSize I
+	public synthetic fun <init> (ILio/matthewnelson/encoding/core/util/buffer/FeedBuffer$Flush;Lio/matthewnelson/encoding/core/util/buffer/FeedBuffer$Finalize;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected abstract fun buffer (Lio/matthewnelson/encoding/core/internal/Internal;)[Ljava/lang/Number;
+	public final fun count ()I
+	public final fun finalize ()V
+	public static final fun truncatedInputEncodingException (I)Lio/matthewnelson/encoding/core/EncodingException;
+	public final fun update (Ljava/lang/Number;)V
+	protected abstract fun zero ()Ljava/lang/Number;
+}
+
+public final class io/matthewnelson/encoding/core/util/buffer/FeedBuffer$Companion {
+	public final fun truncatedInputEncodingException (I)Lio/matthewnelson/encoding/core/EncodingException;
+}
+
+public abstract interface class io/matthewnelson/encoding/core/util/buffer/FeedBuffer$Finalize {
+	public abstract fun invoke (I[Ljava/lang/Number;)V
+}
+
+public abstract interface class io/matthewnelson/encoding/core/util/buffer/FeedBuffer$Flush {
+	public abstract fun invoke ([Ljava/lang/Number;)V
+}
+

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/DecodingBuffer.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/DecodingBuffer.kt
@@ -29,6 +29,8 @@ import io.matthewnelson.encoding.core.internal.InternalEncodingApi
  * @see [FeedBuffer.Finalize]
  * @throws [IllegalArgumentException] if [blockSize] is less
  *   than or equal to 0
+ * @sample [io.matthewnelson.encoding.base64.Base64.newDecoderFeed]
+ * @sample [io.matthewnelson.encoding.base64.Base64.Base64DecodingBuffer]
  * */
 public abstract class DecodingBuffer
 @Throws(IllegalArgumentException::class)

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/DecodingBuffer.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/DecodingBuffer.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("SpellCheckingInspection")
+
+package io.matthewnelson.encoding.core.util.buffer
+
+import io.matthewnelson.encoding.core.Decoder
+import io.matthewnelson.encoding.core.internal.Internal
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+
+/**
+ * Helper for buffering [Decoder.Feed] input.
+ *
+ * @see [FeedBuffer]
+ * @see [FeedBuffer.Flush]
+ * @see [FeedBuffer.Finalize]
+ * @throws [IllegalArgumentException] if [blockSize] is less
+ *   than or equal to 0
+ * */
+public abstract class DecodingBuffer
+@Throws(IllegalArgumentException::class)
+constructor(
+    blockSize: Int,
+    flush: Flush<Int>,
+    finalize: Finalize<Int>
+): FeedBuffer<Int>(blockSize, flush, finalize) {
+    @Suppress("RemoveExplicitTypeArguments")
+    private val buffer = Array<Int>(blockSize) { 0 }
+    @OptIn(InternalEncodingApi::class)
+    protected final override fun buffer(internal: Internal): Array<Int> = buffer
+    protected final override fun zero(): Int = 0
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/EncodingBuffer.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/EncodingBuffer.kt
@@ -29,6 +29,8 @@ import io.matthewnelson.encoding.core.internal.InternalEncodingApi
  * @see [FeedBuffer.Finalize]
  * @throws [IllegalArgumentException] if [blockSize] is less
  *   than or equal to 0
+ * @sample [io.matthewnelson.encoding.base64.Base64.newEncoderFeed]
+ * @sample [io.matthewnelson.encoding.base64.Base64.Base64EncodingBuffer]
  * */
 public abstract class EncodingBuffer
 @Throws(IllegalArgumentException::class)

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/EncodingBuffer.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/EncodingBuffer.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+@file:Suppress("SpellCheckingInspection")
+
+package io.matthewnelson.encoding.core.util.buffer
+
+import io.matthewnelson.encoding.core.Encoder
+import io.matthewnelson.encoding.core.internal.Internal
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+
+/**
+ * Helper for buffering [Encoder.Feed] input.
+ *
+ * @see [FeedBuffer]
+ * @see [FeedBuffer.Flush]
+ * @see [FeedBuffer.Finalize]
+ * @throws [IllegalArgumentException] if [blockSize] is less
+ *   than or equal to 0
+ * */
+public abstract class EncodingBuffer
+@Throws(IllegalArgumentException::class)
+constructor(
+    blockSize: Int,
+    flush: Flush<Byte>,
+    finalize: Finalize<Byte>
+): FeedBuffer<Byte>(blockSize, flush, finalize) {
+    private val buffer = Array<Byte>(blockSize) { 0 }
+    @OptIn(InternalEncodingApi::class)
+    protected final override fun buffer(internal: Internal): Array<Byte> = buffer
+    protected final override fun zero(): Byte = 0
+}

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/FeedBuffer.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/util/buffer/FeedBuffer.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core.util.buffer
+
+import io.matthewnelson.encoding.core.Decoder
+import io.matthewnelson.encoding.core.Encoder
+import io.matthewnelson.encoding.core.EncodingException
+import io.matthewnelson.encoding.core.OutFeed
+import io.matthewnelson.encoding.core.internal.Internal
+import io.matthewnelson.encoding.core.internal.InternalEncodingApi
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmStatic
+
+/**
+ * Helper class for [Decoder.Feed] and [Encoder.Feed]s
+ * to buffer their input until they are ready to output
+ * data to their [OutFeed]s.
+ *
+ * @see [DecodingBuffer]
+ * @see [EncodingBuffer]
+ * @see [Flush]
+ * @see [Finalize]
+ * @see [truncatedInputEncodingException]
+ * @throws [IllegalArgumentException] if [blockSize] is less
+ *   than or equal to 0
+ * */
+@OptIn(InternalEncodingApi::class)
+public sealed class FeedBuffer<T: Number>
+@Throws(IllegalArgumentException::class)
+constructor(
+    @JvmField
+    public val blockSize: Int,
+    private val flush: Flush<T>,
+    private val finalize: Finalize<T>,
+) {
+
+    init {
+        require(blockSize > 0) {
+            "blockSize must be greater than 0"
+        }
+    }
+
+    @get:JvmName("count")
+    public var count: Int = 0
+        private set
+
+    /**
+     * Update the [buffer] with new input.
+     *
+     * Will automatically invoke [flush] in order
+     * to output data once the [buffer] fills.
+     * */
+    public fun update(input: T) {
+        val buffer = buffer(Internal.get())
+        buffer[count] = input
+
+        if (++count % blockSize == 0) {
+            flush.invoke(buffer)
+            count = 0
+        }
+    }
+
+    /**
+     * Call whenever [Encoder.Feed.doFinalProtected] or
+     * [Decoder.Feed.doFinalProtected] is invoked to
+     * process the remaining input in the [buffer].
+     * */
+    public fun finalize() {
+        val buffer = buffer(Internal.get())
+        buffer.fill(zero(), count)
+        finalize.invoke(count % blockSize, buffer)
+        buffer.fill(zero(), 0, count)
+        count = 0
+    }
+
+    /**
+     * [Flush.invoke] will be called once the [buffer]
+     * fills up, and pass it along to perform bitwise
+     * operations before outputting data.
+     *
+     * @see [update]
+     * */
+    public fun interface Flush<T: Number> {
+        public fun invoke(buffer: Array<T>)
+    }
+
+    /**
+     * [Finalize.invoke] will be called whenever [finalize]
+     * is called to process remaining data in the [buffer]
+     *
+     * @see [finalize]
+     * */
+    public fun interface Finalize<T: Number> {
+        public fun invoke(modulus: Int, buffer: Array<T>)
+    }
+
+    public companion object {
+
+        /**
+         * Helper for generating a standard [EncodingException] when
+         * an illegal modulus is encountered while decoding.
+         * */
+        @JvmStatic
+        public fun truncatedInputEncodingException(modulus: Int): EncodingException {
+            return EncodingException("Truncate input. Illegal Modulus[$modulus]")
+        }
+    }
+
+    protected abstract fun buffer(internal: Internal): Array<T>
+    protected abstract fun zero(): T
+}


### PR DESCRIPTION
Closes #42 

This PR:
 - Implements encoding/decoding for all variants of `Base64` (`Default`, `UrlSafe`) using the new `EncoderDecoder`
 - Maps the old encoding/decoding extension function bodies to use the new `EncoderDecoder` for `Base64`
 - Introduces a final `Buffer` implementation (`FeedBuffer`) that I am happy with
     - Still need to convert other encoders over to use. Will be done in separate issues from this.
     - UPDATE: Created #63 to handle this.