### PR TITLE
Refactor `DecoderInput`

### DIFF
--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -72,8 +72,12 @@ public class Base16(config: Config): EncoderDecoder(config) {
         public val encodeToLowercase: Boolean,
     ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
-        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+        override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
             return encodedSize / 2L
+        }
+
+        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput): Int {
+            return encodedSize / 2
         }
 
         @Throws(EncodingSizeException::class)

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -86,50 +86,51 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val checkSymbol: Char?,
         ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
+            override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
+                return encodedSize.decodeOutMaxSize()
+            }
+
             @Throws(EncodingException::class)
-            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput): Int {
                 var outSize = encodedSize
 
-                if (input != null) {
-                    val check = checkSymbol
-                    val actual = input[input.lastRelevantCharacter - 1]
+                val actual = input[encodedSize - 1]
 
-                    if (check != null) {
-                        // Uppercase them so that little 'u' is always
-                        // compared as big 'U'.
-                        val checkUpper = check.uppercaseChar()
-                        val actualUpper = actual.uppercaseChar()
+                if (checkSymbol != null) {
+                    // Uppercase them so that little 'u' is always
+                    // compared as big 'U'.
+                    val checkUpper = checkSymbol.uppercaseChar()
+                    val actualUpper = actual.uppercaseChar()
 
-                        if (actualUpper != checkUpper) {
-                            // Must have a matching checkSymbol
+                    if (actualUpper != checkUpper) {
+                        // Must have a matching checkSymbol
 
-                            if (actual.isCheckSymbol()) {
-                                throw EncodingException(
-                                    "Check symbol did not match. Expected[$checkUpper], Actual[$actual]"
-                                )
-                            } else {
-                                throw EncodingException(
-                                    "Check symbol not found. Expected[$checkUpper]"
-                                )
-                            }
-                        } else {
-                            outSize--
-                        }
-                    } else {
-                        // Mine as well check it here before actually
-                        // decoding because otherwise it will fail on
-                        // the very last byte.
                         if (actual.isCheckSymbol()) {
                             throw EncodingException(
-                                "Decoder Misconfiguration.\n" +
-                                "Check symbol for encoded data was [$actual], but the " +
-                                "decoder is configured to reject check symbols."
+                                "Check symbol did not match. Expected[$checkUpper], Actual[$actual]"
+                            )
+                        } else {
+                            throw EncodingException(
+                                "Check symbol not found. Expected[$checkUpper]"
                             )
                         }
+                    } else {
+                        outSize--
+                    }
+                } else {
+                    // Mine as well check it here before actually
+                    // decoding because otherwise it will fail on
+                    // the very last byte.
+                    if (actual.isCheckSymbol()) {
+                        throw EncodingException(
+                            "Decoder Misconfiguration.\n" +
+                            "Check symbol for encoded data was [$actual], but the " +
+                            "decoder is configured to reject check symbols."
+                        )
                     }
                 }
 
-                return outSize.decodeOutMaxSize()
+                return outSize.toLong().decodeOutMaxSize().toInt()
             }
 
             override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
@@ -404,8 +405,12 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+            override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
                 return encodedSize.decodeOutMaxSize()
+            }
+
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput): Int {
+                return encodedSize.toLong().decodeOutMaxSize().toInt()
             }
 
             override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
@@ -569,8 +574,12 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
             public val padEncoded: Boolean,
         ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+            override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
                 return encodedSize.decodeOutMaxSize()
+            }
+
+            override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput): Int {
+                return encodedSize.toLong().decodeOutMaxSize().toInt()
             }
 
             override fun encodeOutSizeProtected(unEncodedSize: Long): Long {

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -80,9 +80,13 @@ public class Base64(config: Base64.Config): EncoderDecoder(config) {
         public val padEncoded: Boolean,
     ): EncoderDecoder.Config(isLenient, paddingByte = '='.byte) {
 
-        @Throws(EncodingException::class)
-        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+        override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
             return (encodedSize * 6L / 8L)
+        }
+
+        @Throws(EncodingException::class)
+        override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput): Int {
+            return decodeOutMaxSizeProtected(encodedSize.toLong()).toInt()
         }
 
         override fun encodeOutSizeProtected(unEncodedSize: Long): Long {

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -59,8 +59,10 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field isLenient Ljava/lang/Boolean;
 	public final field paddingByte Ljava/lang/Byte;
 	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Byte;)V
-	public final fun decodeOutMaxSizeOrFail (JLio/matthewnelson/encoding/core/util/DecoderInput;)J
-	protected abstract fun decodeOutMaxSizeOrFailProtected (JLio/matthewnelson/encoding/core/util/DecoderInput;)J
+	public final fun decodeOutMaxSize (J)J
+	public final fun decodeOutMaxSizeOrFail (Lio/matthewnelson/encoding/core/util/DecoderInput;)I
+	protected abstract fun decodeOutMaxSizeOrFailProtected (ILio/matthewnelson/encoding/core/util/DecoderInput;)I
+	protected abstract fun decodeOutMaxSizeProtected (J)J
 	public final fun encodeOutSize (J)J
 	protected abstract fun encodeOutSizeProtected (J)J
 	public final fun equals (Ljava/lang/Object;)Z
@@ -110,20 +112,13 @@ public abstract interface annotation class io/matthewnelson/encoding/core/intern
 
 public final class io/matthewnelson/encoding/core/util/DecoderInput {
 	public static final field Companion Lio/matthewnelson/encoding/core/util/DecoderInput$Companion;
-	public final field lastRelevantCharacter I
-	public synthetic fun <init> (Lio/matthewnelson/encoding/core/EncoderDecoder$Config;Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun decodeOutMaxSize ()I
+	public fun <init> (Ljava/lang/CharSequence;)V
+	public fun <init> ([B)V
+	public fun <init> ([C)V
 	public final fun get (I)C
-	public static final synthetic fun isLenientFalseEncodingException$encoding_core ()Lio/matthewnelson/encoding/core/EncodingException;
-	public static final fun toDecoderInput (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
-	public static final fun toDecoderInput ([BLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
-	public static final fun toDecoderInput ([CLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 }
 
 public final class io/matthewnelson/encoding/core/util/DecoderInput$Companion {
-	public final fun toDecoderInput (Ljava/lang/CharSequence;Lio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
-	public final fun toDecoderInput ([BLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
-	public final fun toDecoderInput ([CLio/matthewnelson/encoding/core/EncoderDecoder$Config;)Lio/matthewnelson/encoding/core/util/DecoderInput;
 }
 
 public final class io/matthewnelson/encoding/core/util/_ConversionsKt {

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -18,8 +18,8 @@
 package io.matthewnelson.encoding.core
 
 import io.matthewnelson.encoding.core.internal.decode
+import io.matthewnelson.encoding.core.util.DecoderInput
 import io.matthewnelson.encoding.core.util.buffer.DecodingBuffer
-import io.matthewnelson.encoding.core.util.DecoderInput.Companion.toDecoderInput
 import io.matthewnelson.encoding.core.util.byte
 import kotlin.jvm.JvmStatic
 
@@ -79,11 +79,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun CharSequence.decodeToByteArray(decoder: Decoder): ByteArray {
-            val input = toDecoderInput(decoder.config)
-
-            return decoder.decode(input) { feed ->
-                for (i in 0 until input.lastRelevantCharacter) {
-                    feed.update(this[i].byte)
+            return decoder.decode(decoder.config, DecoderInput(this)) { feed ->
+                forEach { c ->
+                    feed.update(c.byte)
                 }
             }
         }
@@ -108,11 +106,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun CharArray.decodeToByteArray(decoder: Decoder): ByteArray {
-            val input = toDecoderInput(decoder.config)
-
-            return decoder.decode(input) { feed ->
-                for (i in 0 until input.lastRelevantCharacter) {
-                    feed.update(this[i].byte)
+            return decoder.decode(decoder.config, DecoderInput(this)) { feed ->
+                forEach { c ->
+                    feed.update(c.byte)
                 }
             }
         }
@@ -137,11 +133,9 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun ByteArray.decodeToByteArray(decoder: Decoder): ByteArray {
-            val input = toDecoderInput(decoder.config)
-
-            return decoder.decode(input) { feed ->
-                for (i in 0 until input.lastRelevantCharacter) {
-                    feed.update(this[i])
+            return decoder.decode(decoder.config, DecoderInput(this)) { feed ->
+                forEach { b ->
+                    feed.update(b)
                 }
             }
         }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Decoder.kt
@@ -79,7 +79,7 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun CharSequence.decodeToByteArray(decoder: Decoder): ByteArray {
-            return decoder.decode(decoder.config, DecoderInput(this)) { feed ->
+            return decoder.decode(DecoderInput(this)) { feed ->
                 forEach { c ->
                     feed.update(c.byte)
                 }
@@ -106,7 +106,7 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun CharArray.decodeToByteArray(decoder: Decoder): ByteArray {
-            return decoder.decode(decoder.config, DecoderInput(this)) { feed ->
+            return decoder.decode(DecoderInput(this)) { feed ->
                 forEach { c ->
                     feed.update(c.byte)
                 }
@@ -133,7 +133,7 @@ public sealed class Decoder(public val config: EncoderDecoder.Config) {
         @Throws(EncodingException::class)
         @OptIn(ExperimentalEncodingApi::class)
         public fun ByteArray.decodeToByteArray(decoder: Decoder): ByteArray {
-            return decoder.decode(decoder.config, DecoderInput(this)) { feed ->
+            return decoder.decode(DecoderInput(this)) { feed ->
                 forEach { b ->
                     feed.update(b)
                 }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
@@ -28,7 +28,6 @@ import kotlin.contracts.contract
 @Throws(EncodingException::class)
 @OptIn(ExperimentalEncodingApi::class, ExperimentalContracts::class)
 internal inline fun Decoder.decode(
-    config: Config,
     input: DecoderInput,
     update: (feed: Decoder.Feed) -> Unit
 ): ByteArray {

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
@@ -44,7 +44,7 @@ internal inline fun Decoder.decode(
             ba[i++] = byte
         } catch (e: IndexOutOfBoundsException) {
             // Something is wrong with the encoder's pre-calculation
-            throw EncodingSizeException("Encoder's pre-calculation of size[${size}] was incorrect", e)
+            throw EncodingSizeException("Encoder's pre-calculation of Size[$size] was incorrect", e)
         }
     }.use { feed ->
         update.invoke(feed)

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-Helpers.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-Helpers.kt
@@ -17,24 +17,10 @@
 
 package io.matthewnelson.encoding.core.internal
 
-import io.matthewnelson.encoding.core.EncoderDecoder
-import io.matthewnelson.encoding.core.EncodingException
-
-/**
- * Helper for checking if a character is a space or
- * new line.
- *
- * @return true if the character matches '\n', '\r', ' ', or '\t'
- * */
 @Suppress("NOTHING_TO_INLINE")
 internal inline fun Char.isSpaceOrNewLine(): Boolean {
     return when(this) {
         '\n', '\r', ' ', '\t' -> true
         else -> false
     }
-}
-
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun EncoderDecoder.Feed.closedException(): EncodingException {
-    return EncodingException("$this is closed")
 }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/Internal.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/Internal.kt
@@ -18,8 +18,9 @@ package io.matthewnelson.encoding.core.internal
 import kotlin.jvm.JvmSynthetic
 
 /**
- * Something to pass as an argument to public
- * functions which only this module can access.
+ * Something to pass as an argument to protected
+ * functions which only this module can access, so
+ * inheritors cannot.
  * */
 @InternalEncodingApi
 public class Internal private constructor() {

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
@@ -16,6 +16,7 @@
 package io.matthewnelson.encoding.core
 
 import io.matthewnelson.encoding.core.helpers.TestConfig
+import io.matthewnelson.encoding.core.util.DecoderInput
 import kotlin.test.Test
 import kotlin.test.fail
 
@@ -27,13 +28,16 @@ class EncoderDecoderConfigUnitTest {
             encodeReturn = {
                 fail("Should not make it here")
             },
+            decodeInputReturn = {
+                fail("Should not make it here")
+            },
             decodeReturn = {
                 fail("Should not make it here")
             }
         )
 
         try {
-            config.decodeOutMaxSizeOrFail(-1L, null)
+            config.decodeOutMaxSize(-1L)
             fail()
         } catch (_: EncodingSizeException) {
             // pass
@@ -51,11 +55,19 @@ class EncoderDecoderConfigUnitTest {
     fun givenConfig_whenNegativeValuesReturned_thenThrowsEncodingSizeException() {
         val config = TestConfig(
             encodeReturn = { -1L },
+            decodeInputReturn = { -1 },
             decodeReturn = { -1L }
         )
 
         try {
-            config.decodeOutMaxSizeOrFail(5, null)
+            config.decodeOutMaxSize(5)
+            fail()
+        } catch (_: EncodingSizeException) {
+            // pass
+        }
+
+        try {
+            config.decodeOutMaxSizeOrFail(DecoderInput("a"))
             fail()
         } catch (_: EncodingSizeException) {
             // pass
@@ -73,10 +85,12 @@ class EncoderDecoderConfigUnitTest {
     fun givenConfig_whenPositiveValuesSentAndReturned_thenDoseNotThrowException() {
         val config = TestConfig(
             encodeReturn = { 1L },
+            decodeInputReturn = { 1 },
             decodeReturn = { 1L },
         )
 
-        config.decodeOutMaxSizeOrFail(1L, null)
+        config.decodeOutMaxSizeOrFail(DecoderInput("a"))
+        config.decodeOutMaxSize(1L)
         config.encodeOutSize(1L)
     }
 
@@ -84,10 +98,12 @@ class EncoderDecoderConfigUnitTest {
     fun givenConfig_whenZeroPassed_thenReturns0Immediately() {
         val config = TestConfig(
             encodeReturn = { fail("Should not make it here") },
+            decodeInputReturn = { fail("Should not make it here") },
             decodeReturn = { fail("Should not make it here") },
         )
 
-        config.decodeOutMaxSizeOrFail(0L, null)
+        config.decodeOutMaxSizeOrFail(DecoderInput(""))
+        config.decodeOutMaxSize(0L)
         config.encodeOutSize(0L)
     }
 
@@ -95,10 +111,12 @@ class EncoderDecoderConfigUnitTest {
     fun givenConfig_whenZeroReturned_thenDoesNotThrowException() {
         val config = TestConfig(
             encodeReturn = { 0L },
+            decodeInputReturn = { 0 },
             decodeReturn = { 0L },
         )
 
-        config.decodeOutMaxSizeOrFail(1L, null)
+        config.decodeOutMaxSizeOrFail(DecoderInput("a"))
+        config.decodeOutMaxSize(1L)
         config.encodeOutSize(1L)
     }
 }

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestConfig.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestConfig.kt
@@ -25,10 +25,14 @@ class TestConfig(
     isLenient: Boolean? = false,
     paddingByte: Byte? = '='.byte,
     private val encodeReturn: (unEncodedSize: Long) -> Long = { -1L },
+    private val decodeInputReturn: (encodedSize: Int) -> Int = { -1 },
     private val decodeReturn: (encodedSize: Long) -> Long = { -1L },
 ): EncoderDecoder.Config(isLenient, paddingByte) {
-    override fun decodeOutMaxSizeOrFailProtected(encodedSize: Long, input: DecoderInput?): Long {
+    override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
         return decodeReturn.invoke(encodedSize)
+    }
+    override fun decodeOutMaxSizeOrFailProtected(encodedSize: Int, input: DecoderInput): Int {
+        return decodeInputReturn.invoke(encodedSize)
     }
     override fun encodeOutSizeProtected(unEncodedSize: Long): Long {
         return encodeReturn.invoke(unEncodedSize)


### PR DESCRIPTION
Closes #61 

`DecoderInput` no longer has a dependency on `EncoderDecoder.Config`, and a wholly separate method was created for gauging the decode output.