### PR TITLE
Remove case sensitivity from `Base16` and `Base32` decoding

### DIFF
--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -18,13 +18,11 @@ public final class io/matthewnelson/encoding/base16/Base16$Companion {
 }
 
 public final class io/matthewnelson/encoding/base16/Base16$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
-	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
-	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/builders/Base16ConfigBuilder {
-	public field acceptLowercase Z
 	public field encodeToLowercase Z
 	public field isLenient Z
 	public fun <init> ()V

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -29,7 +29,6 @@ import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 @InternalEncodingApi
 internal val COMPATIBILITY: Base16 = Base16 {
     isLenient = true
-    acceptLowercase = false
     encodeToLowercase = false
 }
 

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -67,8 +67,6 @@ public class Base16(config: Config): EncoderDecoder(config) {
     public class Config private constructor(
         isLenient: Boolean,
         @JvmField
-        public val acceptLowercase: Boolean,
-        @JvmField
         public val encodeToLowercase: Boolean,
     ): EncoderDecoder.Config(isLenient, paddingByte = null) {
 
@@ -91,9 +89,6 @@ public class Base16(config: Config): EncoderDecoder(config) {
 
         override fun toStringAddSettings(sb: StringBuilder) {
             with(sb) {
-                append("    acceptLowercase: ")
-                append(acceptLowercase)
-                appendLine()
                 append("    encodeToLowercase: ")
                 append(encodeToLowercase)
             }
@@ -105,7 +100,6 @@ public class Base16(config: Config): EncoderDecoder(config) {
             internal fun from(builder: Base16ConfigBuilder): Config {
                 return Config(
                     isLenient = builder.isLenient,
-                    acceptLowercase = builder.acceptLowercase,
                     encodeToLowercase = builder.encodeToLowercase,
                 )
             }
@@ -150,13 +144,7 @@ public class Base16(config: Config): EncoderDecoder(config) {
 
             @Throws(EncodingException::class)
             override fun updateProtected(input: Byte) {
-                val char = if ((config as Config).acceptLowercase) {
-                    input.char.uppercaseChar()
-                } else {
-                    input.char
-                }
-
-                val bits: Int = when (char) {
+                val bits: Int = when (val char = input.char.uppercaseChar()) {
                     in '0'..'9' -> {
                         // char ASCII value
                         // 0     48    0

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -73,7 +73,6 @@ public class Base16ConfigBuilder {
     public constructor(config: Config?): this() {
         if (config == null) return
         isLenient = config.isLenient ?: true
-        acceptLowercase = config.acceptLowercase
         encodeToLowercase = config.encodeToLowercase
     }
 
@@ -86,16 +85,6 @@ public class Base16ConfigBuilder {
      * */
     @JvmField
     public var isLenient: Boolean = true
-
-    /**
-     * If true, will accept lowercase **AND** uppercase
-     * characters when decoding (against RFC 4648).
-     *
-     * If false, an [EncodingException] will be thrown if
-     * lowercase characters are encountered when decoding.
-     * */
-    @JvmField
-    public var acceptLowercase: Boolean = true
 
     /**
      * If true, will output lowercase characters when
@@ -113,7 +102,6 @@ public class Base16ConfigBuilder {
      * */
     public fun strict(): Base16ConfigBuilder {
         isLenient = false
-        acceptLowercase = false
         encodeToLowercase = false
         return this
     }

--- a/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/component/encoding/base16/Base16UnitTest.kt
+++ b/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/component/encoding/base16/Base16UnitTest.kt
@@ -22,7 +22,6 @@ class Base16UnitTest: BaseEncodingTestBase() {
 
     override val decodeFailureDataSet: Set<Data<String, Any?>> = setOf(
         Data(raw = "A=", expected = null, message = "Typical padding character '=' should return null"),
-        Data(raw = "666f" /* fo */, expected = null, message = "Lower case character should return null"),
         Data(raw = "666", expected = null, message = "Truncated value should return null"),
         Data(raw = "6", expected = null, message = "Truncated value should return null"),
         Data(raw = "AG", expected = null, message = "Character 'G' should return null"),
@@ -86,6 +85,7 @@ class Base16UnitTest: BaseEncodingTestBase() {
         Data(raw = "524142204F", expected = "RAB O".encodeToByteArray()),
         Data(raw = "524142204F4F", expected = "RAB OO".encodeToByteArray()),
         Data(raw = "524142204F4F46", expected = "RAB OOF".encodeToByteArray()),
+        Data(raw = "524142204f4f46", expected = "RAB OOF".encodeToByteArray()),
     )
 
     override val encodeSuccessDataSet: Set<Data<String, String>> = setOf(

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -83,10 +83,9 @@ public final class io/matthewnelson/encoding/base32/Base32$Default$Companion {
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Default$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
-	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
-	public synthetic fun <init> (ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelson/encoding/base32/Base32 {
@@ -101,10 +100,9 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex$Companion {
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Hex$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
-	public final field acceptLowercase Z
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
-	public synthetic fun <init> (ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder {
@@ -120,7 +118,6 @@ public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuild
 }
 
 public final class io/matthewnelson/encoding/builders/Base32DefaultConfigBuilder {
-	public field acceptLowercase Z
 	public field encodeToLowercase Z
 	public field isLenient Z
 	public field padEncoded Z
@@ -131,7 +128,6 @@ public final class io/matthewnelson/encoding/builders/Base32DefaultConfigBuilder
 }
 
 public final class io/matthewnelson/encoding/builders/Base32HexConfigBuilder {
-	public field acceptLowercase Z
 	public field encodeToLowercase Z
 	public field isLenient Z
 	public field padEncoded Z

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
@@ -38,7 +38,6 @@ import kotlin.jvm.JvmOverloads
 @InternalEncodingApi
 internal val COMPATIBILITY_DEFAULT: io.matthewnelson.encoding.base32.Base32.Default = Base32Default {
     isLenient = true
-    acceptLowercase = false
     encodeToLowercase = false
     padEncoded = true
 }
@@ -47,7 +46,6 @@ internal val COMPATIBILITY_DEFAULT: io.matthewnelson.encoding.base32.Base32.Defa
 @InternalEncodingApi
 internal val COMPATIBILITY_HEX: io.matthewnelson.encoding.base32.Base32.Hex = Base32Hex {
     isLenient = true
-    acceptLowercase = false
     encodeToLowercase = false
     padEncoded = true
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -124,8 +124,8 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                     if (actual.isCheckSymbol()) {
                         throw EncodingException(
                             "Decoder Misconfiguration.\n" +
-                            "Check symbol for encoded data was [$actual], but the " +
-                            "decoder is configured to reject check symbols."
+                            "Encoded data had Checksymbol[$actual], but the " +
+                            "decoder is configured to reject."
                         )
                     }
                 }
@@ -279,7 +279,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                                 }
                                 else -> {
                                     throw EncodingException(
-                                        "Char[${input.char}] IS a checkSymbol, but did not match Config[$checkSymbol]"
+                                        "Char[${input.char}] IS a checkSymbol, but did not match config's Checksymbol[$checkSymbol]"
                                     )
                                 }
                             }
@@ -398,8 +398,6 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
         public class Config private constructor(
             isLenient: Boolean,
             @JvmField
-            public val acceptLowercase: Boolean,
-            @JvmField
             public val encodeToLowercase: Boolean,
             @JvmField
             public val padEncoded: Boolean,
@@ -419,8 +417,6 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
 
             override fun toStringAddSettings(sb: StringBuilder) {
                 with(sb) {
-                    append("    acceptLowercase: ")
-                    append(acceptLowercase)
                     appendLine()
                     append("    encodeToLowercase: ")
                     append(encodeToLowercase)
@@ -436,7 +432,6 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                 internal fun from(builder: Base32DefaultConfigBuilder): Config {
                     return Config(
                         isLenient = builder.isLenient,
-                        acceptLowercase = builder.acceptLowercase,
                         encodeToLowercase = builder.encodeToLowercase,
                         padEncoded = builder.padEncoded,
                     )
@@ -462,13 +457,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
 
                 @Throws(EncodingException::class)
                 override fun updateProtected(input: Byte) {
-                    val char = if ((config as Default.Config).acceptLowercase) {
-                        input.char.uppercaseChar()
-                    } else {
-                        input.char
-                    }
-
-                    val bits: Int = when (char) {
+                    val bits: Int = when (val char = input.char.uppercaseChar()) {
                         in '2'..'7' -> {
                             // char ASCII value
                             //  2    50    26
@@ -567,8 +556,6 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
         public class Config private constructor(
             isLenient: Boolean,
             @JvmField
-            public val acceptLowercase: Boolean,
-            @JvmField
             public val encodeToLowercase: Boolean,
             @JvmField
             public val padEncoded: Boolean,
@@ -588,9 +575,6 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
 
             override fun toStringAddSettings(sb: StringBuilder) {
                 with(sb) {
-                    append("    acceptLowercase: ")
-                    append(acceptLowercase)
-                    appendLine()
                     append("    encodeToLowercase: ")
                     append(encodeToLowercase)
                     appendLine()
@@ -605,7 +589,6 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
                 internal fun from(builder: Base32HexConfigBuilder): Config {
                     return Config(
                         isLenient = builder.isLenient,
-                        acceptLowercase = builder.acceptLowercase,
                         encodeToLowercase = builder.encodeToLowercase,
                         padEncoded = builder.padEncoded,
                     )
@@ -631,13 +614,7 @@ public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config
 
                 @Throws(EncodingException::class)
                 override fun updateProtected(input: Byte) {
-                    val char = if ((config as Hex.Config).acceptLowercase) {
-                        input.char.uppercaseChar()
-                    } else {
-                        input.char
-                    }
-
-                    val bits: Int = when (char) {
+                    val bits: Int = when (val char = input.char.uppercaseChar()) {
                         in '0'..'9' -> {
                             // char ASCII value
                             //  0    48    0

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -252,7 +252,6 @@ public class Base32DefaultConfigBuilder {
     public constructor(config: Base32.Default.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient ?: true
-        acceptLowercase = config.acceptLowercase
         encodeToLowercase = config.encodeToLowercase
         padEncoded = config.padEncoded
     }
@@ -266,16 +265,6 @@ public class Base32DefaultConfigBuilder {
      * */
     @JvmField
     public var isLenient: Boolean = true
-
-    /**
-     * If true, will accept lowercase **AND** uppercase
-     * characters when decoding (against RFC 4648).
-     *
-     * If false, an [EncodingException] will be thrown if
-     * lowercase characters are encountered when decoding.
-     * */
-    @JvmField
-    public var acceptLowercase: Boolean = true
 
     /**
      * If true, will output lowercase characters when
@@ -303,7 +292,6 @@ public class Base32DefaultConfigBuilder {
      * */
     public fun strict(): Base32DefaultConfigBuilder {
         isLenient = false
-        acceptLowercase = false
         encodeToLowercase = false
         padEncoded = true
         return this
@@ -327,7 +315,6 @@ public class Base32HexConfigBuilder {
     public constructor(config: Base32.Hex.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient ?: true
-        acceptLowercase = config.acceptLowercase
         encodeToLowercase = config.encodeToLowercase
         padEncoded = config.padEncoded
     }
@@ -341,16 +328,6 @@ public class Base32HexConfigBuilder {
      * */
     @JvmField
     public var isLenient: Boolean = true
-
-    /**
-     * If true, will accept lowercase **AND** uppercase
-     * characters when decoding (against RFC 4648).
-     *
-     * If false, an [EncodingException] will be thrown if
-     * lowercase characters are encountered when decoding.
-     * */
-    @JvmField
-    public var acceptLowercase: Boolean = true
 
     /**
      * If true, will output lowercase characters when
@@ -378,7 +355,6 @@ public class Base32HexConfigBuilder {
      * */
     public fun strict(): Base32HexConfigBuilder {
         isLenient = false
-        acceptLowercase = false
         encodeToLowercase = false
         padEncoded = true
         return this

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32DefaultUnitTest.kt
@@ -24,7 +24,6 @@ class Base32DefaultUnitTest: BaseEncodingTestBase() {
         Data(raw = "A1", expected = null, message = "Character '1' should return null"),
         Data(raw = "A8", expected = null, message = "Character '8' should return null"),
         Data(raw = "A9", expected = null, message = "Character '9' should return null"),
-        Data(raw = "JBSWY3DPEBLW64TMMQQq====", expected = null, message = "Lowercase characters should return null"),
     )
 
     override val decodeSuccessHelloWorld: Data<String, ByteArray> =
@@ -62,6 +61,7 @@ class Base32DefaultUnitTest: BaseEncodingTestBase() {
         Data(raw = "KJAUEICP", expected = "RAB O".encodeToByteArray()),
         Data(raw = "KJAUEICPJ4======", expected = "RAB OO".encodeToByteArray()),
         Data(raw = "KJAUEICPJ5DA====", expected = "RAB OOF".encodeToByteArray()),
+        Data(raw = "kjaueicpj5da====", expected = "RAB OOF".encodeToByteArray()),
     )
 
     override val encodeSuccessDataSet: Set<Data<String, String>> = setOf(

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32HexUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32HexUnitTest.kt
@@ -25,7 +25,6 @@ class Base32HexUnitTest: BaseEncodingTestBase() {
         Data(raw = "AX", expected = null, message = "Character 'X' should return null"),
         Data(raw = "AY", expected = null, message = "Character 'Y' should return null"),
         Data(raw = "AZ", expected = null, message = "Character 'Z' should return null"),
-        Data(raw = "91IMOR3F41BMUSJCCGGg====", expected = null, message = "Lowercase characters should return null"),
     )
 
     override val decodeSuccessHelloWorld: Data<String, ByteArray> =
@@ -63,6 +62,7 @@ class Base32HexUnitTest: BaseEncodingTestBase() {
         Data(raw = "A90K482F", expected = "RAB O".encodeToByteArray()),
         Data(raw = "A90K482F9S======", expected = "RAB OO".encodeToByteArray()),
         Data(raw = "A90K482F9T30====", expected = "RAB OOF".encodeToByteArray()),
+        Data(raw = "a90k482f9t30====", expected = "RAB OOF".encodeToByteArray()),
     )
 
     override val encodeSuccessDataSet: Set<Data<String, String>> = setOf(


### PR DESCRIPTION
Closes #64 