### PR TITLE
Deprecate old code

### DIFF
--- a/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
+++ b/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
@@ -19,16 +19,8 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import by.kirich1409.viewbindingdelegate.viewBinding
-import io.matthewnelson.component.base64.Base64
-import io.matthewnelson.component.base64.encodeBase64
 import io.matthewnelson.component.encoding.app.databinding.ActivityMainBinding
-import io.matthewnelson.component.encoding.base16.encodeBase16
-import io.matthewnelson.component.encoding.base32.Base32
-import io.matthewnelson.component.encoding.base32.encodeBase32
-import io.matthewnelson.encoding.builders.Base16
-import io.matthewnelson.encoding.builders.Base32Crockford
-import io.matthewnelson.encoding.builders.Base32Default
-import io.matthewnelson.encoding.builders.Base32Hex
+import io.matthewnelson.encoding.builders.*
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 
 class MainActivity: AppCompatActivity(R.layout.activity_main) {
@@ -59,6 +51,18 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
             encodeToLowercase = true
             padEncoded = false
         }
+
+        private val base64DefaultEncoderDecoder = Base64 {
+            isLenient = true
+            encodeToUrlSafe = false
+            padEncoded = true
+        }
+
+        private val base64UrlSafeEncoderDecoder = Base64 {
+            isLenient = false
+            encodeToUrlSafe = true
+            padEncoded = false
+        }
     }
 
     private val binding: ActivityMainBinding by viewBinding(ActivityMainBinding::bind)
@@ -74,12 +78,12 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
         val default = bytes.encodeToString(base32DefaultEncoderDecoder)
         val hex = bytes.encodeToString(base32HexEncoderDecoder)
 
-        val base64 = bytes.encodeBase64(Base64.Default)
-        val base64UrlSafe = bytes.encodeBase64(Base64.UrlSafe(pad = true))
+        val base64 = bytes.encodeToString(base64DefaultEncoderDecoder)
+        val base64UrlSafe = bytes.encodeToString(base64UrlSafeEncoderDecoder)
 
         binding.textViewBase16.text = "Base16 (hex):\n$base16"
 
-        binding.textViewCrockford.text = "Base32 Crockford(checkSymbol = *, hyphenInterval = 5):\n$crockford"
+        binding.textViewCrockford.text = "Base32 Crockford[checkSymbol = *, hyphenInterval = 5]:\n$crockford"
         binding.textViewDefault.text = "Base32 Default:\n$default"
         binding.textViewHex.text = "Base32 Hex:\n$hex"
 

--- a/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
+++ b/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
@@ -26,6 +26,9 @@ import io.matthewnelson.component.encoding.base16.encodeBase16
 import io.matthewnelson.component.encoding.base32.Base32
 import io.matthewnelson.component.encoding.base32.encodeBase32
 import io.matthewnelson.encoding.builders.Base16
+import io.matthewnelson.encoding.builders.Base32Crockford
+import io.matthewnelson.encoding.builders.Base32Default
+import io.matthewnelson.encoding.builders.Base32Hex
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 
 class MainActivity: AppCompatActivity(R.layout.activity_main) {
@@ -36,6 +39,25 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
         private val base16EncoderDecoder = Base16 {
             isLenient = false
             encodeToLowercase = true
+        }
+
+        private val base32CrockfordEncoderDecoder = Base32Crockford {
+            isLenient = false
+            encodeToLowercase = false
+            hyphenInterval = 5
+            checkSymbol('*')
+        }
+
+        private val base32DefaultEncoderDecoder = Base32Default {
+            isLenient = false
+            encodeToLowercase = true
+            padEncoded = false
+        }
+
+        private val base32HexEncoderDecoder = Base32Hex {
+            isLenient = false
+            encodeToLowercase = true
+            padEncoded = false
         }
     }
 
@@ -48,16 +70,16 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
 
         val base16 = bytes.encodeToString(base16EncoderDecoder)
 
-        val crockford = bytes.encodeBase32(Base32.Crockford('*'))
-        val default = bytes.encodeBase32(Base32.Default)
-        val hex = bytes.encodeBase32(Base32.Hex)
+        val crockford = bytes.encodeToString(base32CrockfordEncoderDecoder)
+        val default = bytes.encodeToString(base32DefaultEncoderDecoder)
+        val hex = bytes.encodeToString(base32HexEncoderDecoder)
 
         val base64 = bytes.encodeBase64(Base64.Default)
         val base64UrlSafe = bytes.encodeBase64(Base64.UrlSafe(pad = true))
 
         binding.textViewBase16.text = "Base16 (hex):\n$base16"
 
-        binding.textViewCrockford.text = "Base32 Crockford(checkSymbol = *):\n$crockford"
+        binding.textViewCrockford.text = "Base32 Crockford(checkSymbol = *, hyphenInterval = 5):\n$crockford"
         binding.textViewDefault.text = "Base32 Default:\n$default"
         binding.textViewHex.text = "Base32 Hex:\n$hex"
 

--- a/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
+++ b/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
@@ -25,11 +25,18 @@ import io.matthewnelson.component.encoding.app.databinding.ActivityMainBinding
 import io.matthewnelson.component.encoding.base16.encodeBase16
 import io.matthewnelson.component.encoding.base32.Base32
 import io.matthewnelson.component.encoding.base32.encodeBase32
+import io.matthewnelson.encoding.builders.Base16
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 
 class MainActivity: AppCompatActivity(R.layout.activity_main) {
 
     companion object {
         const val HELLO_WORLD = "Hello World!"
+
+        private val base16EncoderDecoder = Base16 {
+            isLenient = false
+            encodeToLowercase = true
+        }
     }
 
     private val binding: ActivityMainBinding by viewBinding(ActivityMainBinding::bind)
@@ -38,17 +45,22 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val bytes = HELLO_WORLD.encodeToByteArray()
-        val base16 = bytes.encodeBase16()
+
+        val base16 = bytes.encodeToString(base16EncoderDecoder)
+
         val crockford = bytes.encodeBase32(Base32.Crockford('*'))
         val default = bytes.encodeBase32(Base32.Default)
         val hex = bytes.encodeBase32(Base32.Hex)
+
         val base64 = bytes.encodeBase64(Base64.Default)
         val base64UrlSafe = bytes.encodeBase64(Base64.UrlSafe(pad = true))
 
         binding.textViewBase16.text = "Base16 (hex):\n$base16"
+
         binding.textViewCrockford.text = "Base32 Crockford(checkSymbol = *):\n$crockford"
         binding.textViewDefault.text = "Base32 Default:\n$default"
         binding.textViewHex.text = "Base32 Hex:\n$hex"
+
         binding.textViewBase64.text = "Base64 Default:\n$base64"
         binding.textViewBase64UrlSafe.text = "Base64 UrlSafe:\n$base64UrlSafe"
     }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -17,45 +17,101 @@
 
 package io.matthewnelson.component.encoding.base16
 
-import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.builders.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 
-@PublishedApi
-@InternalEncodingApi
-internal val COMPATIBILITY: Base16 = Base16 {
-    isLenient = true
-    encodeToLowercase = false
-}
-
+@Deprecated(
+    message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base16 { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase16ToArray(): ByteArray? {
-    @OptIn(InternalEncodingApi::class)
-    return decodeToByteArrayOrNull(COMPATIBILITY)
+    return decodeToByteArrayOrNull(Base16 {
+        isLenient = true
+        encodeToLowercase = false
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base16 { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 public fun CharArray.decodeBase16ToArray(): ByteArray? {
-    @OptIn(InternalEncodingApi::class)
-    return decodeToByteArrayOrNull(COMPATIBILITY)
+    return decodeToByteArrayOrNull(Base16 {
+        isLenient = true
+        encodeToLowercase = false
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToString(Base16 { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase16(): String {
-    @OptIn(InternalEncodingApi::class)
-    return encodeToString(COMPATIBILITY)
+    return encodeToString(Base16 {
+        isLenient = true
+        encodeToLowercase = false
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToCharArray(Base16 { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase16ToCharArray(): CharArray {
-    @OptIn(InternalEncodingApi::class)
-    return encodeToCharArray(COMPATIBILITY)
+    return encodeToCharArray(Base16 {
+        isLenient = true
+        encodeToLowercase = false
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+    ReplaceWith(
+        expression = "this.encodeToByteArray(Base16 { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base16",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 public fun ByteArray.encodeBase16ToByteArray(): ByteArray {
-    @OptIn(InternalEncodingApi::class)
-    return encodeToByteArray(COMPATIBILITY)
+    return encodeToByteArray(Base16 {
+        isLenient = true
+        encodeToLowercase = false
+    })
 }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -52,6 +52,11 @@ import kotlin.jvm.JvmSynthetic
  * @see [Base16.Config]
  * @see [Base16.CHARS]
  * @see [EncoderDecoder]
+ * @see [Decoder.decodeToByteArray]
+ * @see [Decoder.decodeToByteArrayOrNull]
+ * @see [Encoder.encodeToString]
+ * @see [Encoder.encodeToCharArray]
+ * @see [Encoder.encodeToByteArray]
  * */
 @OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
 public class Base16(config: Config): EncoderDecoder(config) {

--- a/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/component/encoding/base16/Base16UnitTest.kt
+++ b/library/encoding-base16/src/commonTest/kotlin/io/matthewnelson/component/encoding/base16/Base16UnitTest.kt
@@ -47,6 +47,7 @@ class Base16UnitTest: BaseEncodingTestBase() {
     )
 
     override fun decode(data: String): ByteArray? {
+        @Suppress("DEPRECATION")
         return data.decodeBase16ToArray()
     }
 
@@ -122,6 +123,7 @@ class Base16UnitTest: BaseEncodingTestBase() {
     )
 
     override fun encode(data: ByteArray): String {
+        @Suppress("DEPRECATION")
         return data.encodeBase16()
     }
 

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -33,20 +33,30 @@ public final class io/matthewnelson/component/encoding/base32/Base32$Hex : io/ma
 
 public final class io/matthewnelson/component/encoding/base32/Base32Kt {
 	public static final fun decodeBase32ToArray (Ljava/lang/String;)[B
-	public static final fun decodeBase32ToArray (Ljava/lang/String;Lio/matthewnelson/component/encoding/base32/Base32;)[B
+	public static final fun decodeBase32ToArray (Ljava/lang/String;Lio/matthewnelson/component/encoding/base32/Base32$Crockford;)[B
+	public static final fun decodeBase32ToArray (Ljava/lang/String;Lio/matthewnelson/component/encoding/base32/Base32$Default;)[B
+	public static final fun decodeBase32ToArray (Ljava/lang/String;Lio/matthewnelson/component/encoding/base32/Base32$Hex;)[B
 	public static final fun decodeBase32ToArray ([C)[B
-	public static final fun decodeBase32ToArray ([CLio/matthewnelson/component/encoding/base32/Base32;)[B
-	public static synthetic fun decodeBase32ToArray$default (Ljava/lang/String;Lio/matthewnelson/component/encoding/base32/Base32;ILjava/lang/Object;)[B
-	public static synthetic fun decodeBase32ToArray$default ([CLio/matthewnelson/component/encoding/base32/Base32;ILjava/lang/Object;)[B
+	public static final fun decodeBase32ToArray ([CLio/matthewnelson/component/encoding/base32/Base32$Crockford;)[B
+	public static final fun decodeBase32ToArray ([CLio/matthewnelson/component/encoding/base32/Base32$Default;)[B
+	public static final fun decodeBase32ToArray ([CLio/matthewnelson/component/encoding/base32/Base32$Hex;)[B
+	public static synthetic fun decodeBase32ToArray$default (Ljava/lang/String;Lio/matthewnelson/component/encoding/base32/Base32$Default;ILjava/lang/Object;)[B
+	public static synthetic fun decodeBase32ToArray$default ([CLio/matthewnelson/component/encoding/base32/Base32$Default;ILjava/lang/Object;)[B
 	public static final fun encodeBase32 ([B)Ljava/lang/String;
-	public static final fun encodeBase32 ([BLio/matthewnelson/component/encoding/base32/Base32;)Ljava/lang/String;
-	public static synthetic fun encodeBase32$default ([BLio/matthewnelson/component/encoding/base32/Base32;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun encodeBase32 ([BLio/matthewnelson/component/encoding/base32/Base32$Crockford;)Ljava/lang/String;
+	public static final fun encodeBase32 ([BLio/matthewnelson/component/encoding/base32/Base32$Default;)Ljava/lang/String;
+	public static final fun encodeBase32 ([BLio/matthewnelson/component/encoding/base32/Base32$Hex;)Ljava/lang/String;
+	public static synthetic fun encodeBase32$default ([BLio/matthewnelson/component/encoding/base32/Base32$Default;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun encodeBase32ToByteArray ([B)[B
-	public static final fun encodeBase32ToByteArray ([BLio/matthewnelson/component/encoding/base32/Base32;)[B
-	public static synthetic fun encodeBase32ToByteArray$default ([BLio/matthewnelson/component/encoding/base32/Base32;ILjava/lang/Object;)[B
+	public static final fun encodeBase32ToByteArray ([BLio/matthewnelson/component/encoding/base32/Base32$Crockford;)[B
+	public static final fun encodeBase32ToByteArray ([BLio/matthewnelson/component/encoding/base32/Base32$Default;)[B
+	public static final fun encodeBase32ToByteArray ([BLio/matthewnelson/component/encoding/base32/Base32$Hex;)[B
+	public static synthetic fun encodeBase32ToByteArray$default ([BLio/matthewnelson/component/encoding/base32/Base32$Default;ILjava/lang/Object;)[B
 	public static final fun encodeBase32ToCharArray ([B)[C
-	public static final fun encodeBase32ToCharArray ([BLio/matthewnelson/component/encoding/base32/Base32;)[C
-	public static synthetic fun encodeBase32ToCharArray$default ([BLio/matthewnelson/component/encoding/base32/Base32;ILjava/lang/Object;)[C
+	public static final fun encodeBase32ToCharArray ([BLio/matthewnelson/component/encoding/base32/Base32$Crockford;)[C
+	public static final fun encodeBase32ToCharArray ([BLio/matthewnelson/component/encoding/base32/Base32$Default;)[C
+	public static final fun encodeBase32ToCharArray ([BLio/matthewnelson/component/encoding/base32/Base32$Hex;)[C
+	public static synthetic fun encodeBase32ToCharArray$default ([BLio/matthewnelson/component/encoding/base32/Base32$Default;ILjava/lang/Object;)[C
 }
 
 public abstract class io/matthewnelson/encoding/base32/Base32 : io/matthewnelson/encoding/core/EncoderDecoder {

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
@@ -19,6 +19,8 @@
     "PrivatePropertyName",
     "RedundantExplicitType",
     "SpellCheckingInspection",
+    "DEPRECATION",
+    "DeprecatedCallableAddReplaceWith", "UNUSED_PARAMETER",
 )
 
 package io.matthewnelson.component.encoding.base32
@@ -30,38 +32,37 @@ import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import io.matthewnelson.encoding.core.internal.InternalEncodingApi
-import io.matthewnelson.encoding.core.util.char
 import kotlin.jvm.JvmOverloads
 
-@PublishedApi
-@InternalEncodingApi
-internal val COMPATIBILITY_DEFAULT: io.matthewnelson.encoding.base32.Base32.Default = Base32Default {
-    isLenient = true
-    encodeToLowercase = false
-    padEncoded = true
-}
-
-@PublishedApi
-@InternalEncodingApi
-internal val COMPATIBILITY_HEX: io.matthewnelson.encoding.base32.Base32.Hex = Base32Hex {
-    isLenient = true
-    encodeToLowercase = false
-    padEncoded = true
-}
-
+@Deprecated(
+    message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "Base32",
+        imports = [
+            "io.matthewnelson.encoding.base32.Base32",
+        ]
+    ),
+    level = DeprecationLevel.WARNING,
+)
 public sealed class Base32 {
 
-    /**
-     * Base32 Crockford encoding in accordance with
-     * https://www.crockford.com/base32.html
-     *
-     * @param [checkSymbol] specify an optional check symbol to be appended when encoding,
-     *  or verified upon decoding.
-     * @throws [IllegalArgumentException] if [checkSymbol] is not one of the accepted
-     *  symbols (*, ~, $, =, U, u) or `null` to omit (omitted by default)
-     * */
-    public data class Crockford @JvmOverloads constructor(val checkSymbol: Char? = null): Base32() {
+    @Deprecated(
+        message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+        replaceWith = ReplaceWith(
+            expression = "Crockford",
+            imports = [
+                "io.matthewnelson.encoding.base32.Base32.Crockford",
+            ]
+        ),
+        level = DeprecationLevel.WARNING,
+    )
+    public data class Crockford @JvmOverloads constructor(
+        @Deprecated(
+            message = "Replaced by EncoderDecoder. Use io.matthewnelson.builders.Base32Crockford to set",
+            level = DeprecationLevel.WARNING
+        )
+        val checkSymbol: Char? = null
+    ): Base32() {
 
         init {
             when (checkSymbol) {
@@ -76,134 +77,344 @@ public sealed class Base32 {
         }
 
         public companion object {
+
+            @Deprecated(
+                message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+                replaceWith = ReplaceWith(
+                    expression = "CHARS",
+                    imports = [
+                        "io.matthewnelson.encoding.base32.Base32.Crockford.CHARS"
+                    ],
+                ),
+                level = DeprecationLevel.WARNING
+            )
             public const val CHARS: String = io.matthewnelson.encoding.base32.Base32.Crockford.CHARS
         }
 
+        @Deprecated(
+            message = "Replaced by EncoderDecoder. Use io.matthewnelson.builders.Base32Crockford to set",
+            level = DeprecationLevel.WARNING
+        )
         inline val hasCheckSymbol: Boolean get() = checkSymbol != null
+
+        @Deprecated(
+            message = "Replaced by EncoderDecoder. Use io.matthewnelson.builders.Base32Crockford to set",
+            level = DeprecationLevel.WARNING
+        )
         inline val checkByte: Byte? get() = checkSymbol?.uppercaseChar()?.code?.toByte()
     }
 
-    /**
-     * Base32 encoding in accordance with RFC 4648 section 6
-     * https://www.ietf.org/rfc/rfc4648.html#section-6
-     * */
+    @Deprecated(
+        message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+        replaceWith = ReplaceWith(
+            expression = "Default",
+            imports = [
+                "io.matthewnelson.encoding.base32.Base32.Default"
+            ]
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     public object Default: Base32() {
+
+        @Deprecated(
+            message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+            replaceWith = ReplaceWith(
+                expression = "CHARS",
+                imports = [
+                    "io.matthewnelson.encoding.base32.Base32.Default.CHARS"
+                ],
+            ),
+            level = DeprecationLevel.WARNING
+        )
         public const val CHARS: String = io.matthewnelson.encoding.base32.Base32.Default.CHARS
     }
 
-    /**
-     * Base32Hex encoding in accordance with RFC 4648 section 7
-     * https://www.ietf.org/rfc/rfc4648.html#section-7
-     * */
+    @Deprecated(
+        message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+        replaceWith = ReplaceWith(
+            expression = "Hex",
+            imports = [
+                "io.matthewnelson.encoding.base32.Base32.Hex"
+            ]
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     public object Hex: Base32() {
+
+        @Deprecated(
+            message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+            replaceWith = ReplaceWith(
+                expression = "CHARS",
+                imports = [
+                    "io.matthewnelson.encoding.base32.Base32.Hex.CHARS"
+                ],
+            ),
+            level = DeprecationLevel.WARNING
+        )
         public const val CHARS: String = io.matthewnelson.encoding.base32.Base32.Hex.CHARS
     }
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base32Default { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
-public inline fun String.decodeBase32ToArray(base32: Base32 = Base32.Default): ByteArray? {
-    @OptIn(InternalEncodingApi::class)
-    return when (base32) {
-        is Base32.Crockford -> {
-            decodeToByteArrayOrNull(Base32Crockford {
-                isLenient = true
-                encodeToLowercase = false
-                hyphenInterval = 0
-                checkSymbol(base32.checkByte?.char)
-            })
-        }
-        is Base32.Default -> {
-            decodeToByteArrayOrNull(COMPATIBILITY_DEFAULT)
-        }
-        is Base32.Hex -> {
-            decodeToByteArrayOrNull(COMPATIBILITY_HEX)
-        }
-    }
+public inline fun String.decodeBase32ToArray(base32: Base32.Default = Base32.Default): ByteArray? {
+    return decodeToByteArrayOrNull(Base32Default { encodeToLowercase = false })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base32Hex { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun String.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
+    return decodeToByteArrayOrNull(Base32Hex { encodeToLowercase = false })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base32Crockford { encodeToLowercase = false; checkSymbol('value') })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun String.decodeBase32ToArray(base32: Base32.Crockford): ByteArray? {
+    return decodeToByteArrayOrNull(Base32Crockford {
+        isLenient = true
+        encodeToLowercase = false
+        hyphenInterval = 0
+        checkSymbol(base32.checkSymbol)
+    })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base32Default { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
-public fun CharArray.decodeBase32ToArray(base32: Base32 = Base32.Default): ByteArray? {
-    @OptIn(InternalEncodingApi::class)
-    return when (base32) {
-        is Base32.Crockford -> {
-            decodeToByteArrayOrNull(Base32Crockford {
-                isLenient = true
-                encodeToLowercase = false
-                hyphenInterval = 0
-                checkSymbol(base32.checkByte?.char)
-            })
-        }
-        is Base32.Default -> {
-            decodeToByteArrayOrNull(COMPATIBILITY_DEFAULT)
-        }
-        is Base32.Hex -> {
-            decodeToByteArrayOrNull(COMPATIBILITY_HEX)
-        }
-    }
+public fun CharArray.decodeBase32ToArray(base32: Base32.Default = Base32.Default): ByteArray? {
+    return decodeToByteArrayOrNull(Base32Default { encodeToLowercase = false })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base32Hex { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+public fun CharArray.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
+    return decodeToByteArrayOrNull(Base32Hex { encodeToLowercase = false })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base32Crockford { encodeToLowercase = false; checkSymbol('value') })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+public fun CharArray.decodeBase32ToArray(base32: Base32.Crockford): ByteArray? {
+    return decodeToByteArrayOrNull(Base32Crockford {
+        isLenient = true
+        encodeToLowercase = false
+        hyphenInterval = 0
+        checkSymbol(base32.checkSymbol)
+    })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToString(Base32Default { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
-public inline fun ByteArray.encodeBase32(base32: Base32 = Base32.Default): String {
-    @OptIn(InternalEncodingApi::class)
-    return when (base32) {
-        is Base32.Crockford -> {
-            encodeToString(Base32Crockford {
-                isLenient = true
-                encodeToLowercase = false
-                hyphenInterval = 0
-                checkSymbol(base32.checkByte?.char)
-            })
-        }
-        is Base32.Default -> {
-            encodeToString(COMPATIBILITY_DEFAULT)
-        }
-        is Base32.Hex -> {
-            encodeToString(COMPATIBILITY_HEX)
-        }
-    }
+public inline fun ByteArray.encodeBase32(base32: Base32.Default = Base32.Default): String {
+    return encodeToString(Base32Default { encodeToLowercase = false })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToString(Base32Hex { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun ByteArray.encodeBase32(base32: Base32.Hex): String {
+    return encodeToString(Base32Hex { encodeToLowercase = false })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToString(Base32Crockford { encodeToLowercase = false; checkSymbol('value') })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun ByteArray.encodeBase32(base32: Base32.Crockford): String {
+    return encodeToString(Base32Crockford {
+        isLenient = true
+        encodeToLowercase = false
+        hyphenInterval = 0
+        checkSymbol(base32.checkSymbol)
+    })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToCharArray(Base32Default { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
-public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32 = Base32.Default): CharArray {
-    @OptIn(InternalEncodingApi::class)
-    return when (base32) {
-        is Base32.Crockford -> {
-            encodeToCharArray(Base32Crockford {
-                isLenient = true
-                encodeToLowercase = false
-                hyphenInterval = 0
-                checkSymbol(base32.checkByte?.char)
-            })
-        }
-        is Base32.Default -> {
-            encodeToCharArray(COMPATIBILITY_DEFAULT)
-        }
-        is Base32.Hex -> {
-            encodeToCharArray(COMPATIBILITY_HEX)
-        }
-    }
+public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Default = Base32.Default): CharArray {
+    return encodeToCharArray(Base32Default { encodeToLowercase = false })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToCharArray(Base32Hex { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Hex): CharArray {
+    return encodeToCharArray(Base32Hex { encodeToLowercase = false })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToCharArray(Base32Crockford { encodeToLowercase = false; checkSymbol('value') })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Crockford): CharArray {
+    return encodeToCharArray(Base32Crockford {
+        isLenient = true
+        encodeToLowercase = false
+        hyphenInterval = 0
+        checkSymbol(base32.checkSymbol)
+    })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToByteArray(Base32Default { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Default",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
-public fun ByteArray.encodeBase32ToByteArray(base32: Base32 = Base32.Default): ByteArray {
-    @OptIn(InternalEncodingApi::class)
-    return when (base32) {
-        is Base32.Crockford -> {
-            encodeToByteArray(Base32Crockford {
-                isLenient = true
-                encodeToLowercase = false
-                hyphenInterval = 0
-                checkSymbol(base32.checkByte?.char)
-            })
-        }
-        is Base32.Default -> {
-            encodeToByteArray(COMPATIBILITY_DEFAULT)
-        }
-        is Base32.Hex -> {
-            encodeToByteArray(COMPATIBILITY_HEX)
-        }
-    }
+public fun ByteArray.encodeBase32ToByteArray(base32: Base32.Default = Base32.Default): ByteArray {
+    return encodeToByteArray(Base32Default { encodeToLowercase = false })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToByteArray(Base32Hex { encodeToLowercase = false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Hex",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+public fun ByteArray.encodeBase32ToByteArray(base32: Base32.Hex): ByteArray {
+    return encodeToByteArray(Base32Hex { encodeToLowercase = false })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToByteArray(Base32Crockford { encodeToLowercase = false; checkSymbol('value') })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base32Crockford",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+public fun ByteArray.encodeBase32ToByteArray(base32: Base32.Crockford): ByteArray {
+    return encodeToByteArray(Base32Crockford {
+        isLenient = true
+        encodeToLowercase = false
+        hyphenInterval = 0
+        checkSymbol(base32.checkSymbol)
+    })
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
@@ -20,7 +20,8 @@
     "RedundantExplicitType",
     "SpellCheckingInspection",
     "DEPRECATION",
-    "DeprecatedCallableAddReplaceWith", "UNUSED_PARAMETER",
+    "DeprecatedCallableAddReplaceWith",
+    "UNUSED_PARAMETER",
 )
 
 package io.matthewnelson.component.encoding.base32
@@ -81,9 +82,9 @@ public sealed class Base32 {
             @Deprecated(
                 message = "Replaced by EncoderDecoder. Will be removed in future versions.",
                 replaceWith = ReplaceWith(
-                    expression = "CHARS",
+                    expression = "Crockford.CHARS",
                     imports = [
-                        "io.matthewnelson.encoding.base32.Base32.Crockford.CHARS"
+                        "io.matthewnelson.encoding.base32.Base32.Crockford"
                     ],
                 ),
                 level = DeprecationLevel.WARNING
@@ -119,9 +120,9 @@ public sealed class Base32 {
         @Deprecated(
             message = "Replaced by EncoderDecoder. Will be removed in future versions.",
             replaceWith = ReplaceWith(
-                expression = "CHARS",
+                expression = "Default.CHARS",
                 imports = [
-                    "io.matthewnelson.encoding.base32.Base32.Default.CHARS"
+                    "io.matthewnelson.encoding.base32.Base32.Default"
                 ],
             ),
             level = DeprecationLevel.WARNING
@@ -144,9 +145,9 @@ public sealed class Base32 {
         @Deprecated(
             message = "Replaced by EncoderDecoder. Will be removed in future versions.",
             replaceWith = ReplaceWith(
-                expression = "CHARS",
+                expression = "Hex.CHARS",
                 imports = [
-                    "io.matthewnelson.encoding.base32.Base32.Hex.CHARS"
+                    "io.matthewnelson.encoding.base32.Base32.Hex"
                 ],
             ),
             level = DeprecationLevel.WARNING

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -37,6 +37,11 @@ import kotlin.jvm.JvmSynthetic
  * @see [Crockford]
  * @see [Default]
  * @see [Hex]
+ * @see [Decoder.decodeToByteArray]
+ * @see [Decoder.decodeToByteArrayOrNull]
+ * @see [Encoder.encodeToString]
+ * @see [Encoder.encodeToCharArray]
+ * @see [Encoder.encodeToByteArray]
  * */
 @OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
 public sealed class Base32(config: EncoderDecoder.Config): EncoderDecoder(config) {

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32CrockfordUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32CrockfordUnitTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("SpellCheckingInspection")
+
 package io.matthewnelson.component.encoding.base32
 
 import io.matthewnelson.component.encoding.test.BaseEncodingTestBase
@@ -20,11 +22,13 @@ import kotlin.test.*
 
 class Base32CrockfordUnitTest: BaseEncodingTestBase() {
 
+    @Suppress("DEPRECATION")
     private var crockford: Base32.Crockford = Base32.Crockford(checkSymbol = null)
     private val validCheckSymbols = listOf('*', '~', '$', '=', 'U', 'u')
 
     @AfterTest
     fun after() {
+        @Suppress("DEPRECATION")
         crockford = Base32.Crockford(checkSymbol = null)
     }
 
@@ -235,19 +239,23 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
     }
 
     override fun decode(data: String): ByteArray? {
+        @Suppress("DEPRECATION")
         return data.decodeBase32ToArray(crockford)
     }
     override fun encode(data: ByteArray): String {
+        @Suppress("DEPRECATION")
         return data.encodeBase32(crockford)
     }
 
     @Test
     fun givenCheckSymbol_whenExpressed_hasCheckReturnsTrue() {
+        @Suppress("DEPRECATION")
         assertTrue(Base32.Crockford(checkSymbol = '=').hasCheckSymbol)
     }
 
     @Test
     fun givenCheckSymbol_whenNotExpressed_hasCheckReturnsFalse() {
+        @Suppress("DEPRECATION")
         assertFalse(Base32.Crockford(checkSymbol = null).hasCheckSymbol)
     }
 
@@ -255,6 +263,7 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
     fun givenCheckSymbol_whenNotAValidSymbol_throwsException() {
         var exception: IllegalArgumentException? = null
         try {
+            @Suppress("DEPRECATION")
             Base32.Crockford('0')
         } catch (e: IllegalArgumentException) {
             exception = e
@@ -283,6 +292,7 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
         val data = encodeSuccessDataSet.first()
 
         for (symbol in validCheckSymbols) {
+            @Suppress("DEPRECATION")
             val decoded = (data.expected + symbol)
                 .decodeBase32ToArray(Base32.Crockford(checkSymbol = null))
             assertNull(decoded)
@@ -292,6 +302,7 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
     @Test
     fun givenEncodedDataWithCheckSymbol_whenDecodedWithCheckSymbolExpressed_returnsExpected() {
         for (symbol in validCheckSymbols) {
+            @Suppress("DEPRECATION")
             crockford = Base32.Crockford(symbol)
             checkEncodeSuccessForDataSet(
                 getEncodeSuccessDataSetWithCheckSymbolExpected(symbol)
@@ -302,6 +313,7 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
     @Test
     fun givenString_whenEncodedWithCheckSymbolExpressed_returnsExpected() {
         for (symbol in validCheckSymbols) {
+            @Suppress("DEPRECATION")
             crockford = Base32.Crockford(symbol)
             checkDecodeSuccessForDataSet(
                 getDecodeSuccessDataSetWithCheckSymbolExpected(symbol)
@@ -318,6 +330,7 @@ class Base32CrockfordUnitTest: BaseEncodingTestBase() {
                 raw = data.raw,
                 expected = "${data.expected}$symbol$symbol"
             )
+            @Suppress("DEPRECATION")
             val decoded = newData.expected.decodeBase32ToArray(base32 = Base32.Crockford(symbol))
             assertNull(decoded)
         }

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32DefaultUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32DefaultUnitTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("SpellCheckingInspection")
+
 package io.matthewnelson.component.encoding.base32
 
 import io.matthewnelson.component.encoding.test.BaseEncodingTestBase
@@ -97,9 +99,11 @@ class Base32DefaultUnitTest: BaseEncodingTestBase() {
     )
 
     override fun decode(data: String): ByteArray? {
+        @Suppress("DEPRECATION")
         return data.decodeBase32ToArray(Base32.Default)
     }
     override fun encode(data: ByteArray): String {
+        @Suppress("DEPRECATION")
         return data.encodeBase32(Base32.Default)
     }
 

--- a/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32HexUnitTest.kt
+++ b/library/encoding-base32/src/commonTest/kotlin/io/matthewnelson/component/encoding/base32/Base32HexUnitTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("SpellCheckingInspection")
+
 package io.matthewnelson.component.encoding.base32
 
 import io.matthewnelson.component.encoding.test.BaseEncodingTestBase
@@ -98,9 +100,11 @@ class Base32HexUnitTest: BaseEncodingTestBase() {
     )
 
     override fun decode(data: String): ByteArray? {
+        @Suppress("DEPRECATION")
         return data.decodeBase32ToArray(Base32.Hex)
     }
     override fun encode(data: ByteArray): String {
+        @Suppress("DEPRECATION")
         return data.encodeBase32(Base32.Hex)
     }
 

--- a/library/encoding-base64/api/encoding-base64.api
+++ b/library/encoding-base64/api/encoding-base64.api
@@ -28,14 +28,17 @@ public final class io/matthewnelson/component/base64/Base64Kt {
 	public static final fun decodeBase64ToArray (Ljava/lang/String;)[B
 	public static final fun decodeBase64ToArray ([C)[B
 	public static final fun encodeBase64 ([B)Ljava/lang/String;
-	public static final fun encodeBase64 ([BLio/matthewnelson/component/base64/Base64;)Ljava/lang/String;
-	public static synthetic fun encodeBase64$default ([BLio/matthewnelson/component/base64/Base64;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun encodeBase64 ([BLio/matthewnelson/component/base64/Base64$Default;)Ljava/lang/String;
+	public static final fun encodeBase64 ([BLio/matthewnelson/component/base64/Base64$UrlSafe;)Ljava/lang/String;
+	public static synthetic fun encodeBase64$default ([BLio/matthewnelson/component/base64/Base64$Default;ILjava/lang/Object;)Ljava/lang/String;
 	public static final fun encodeBase64ToByteArray ([B)[B
-	public static final fun encodeBase64ToByteArray ([BLio/matthewnelson/component/base64/Base64;)[B
-	public static synthetic fun encodeBase64ToByteArray$default ([BLio/matthewnelson/component/base64/Base64;ILjava/lang/Object;)[B
+	public static final fun encodeBase64ToByteArray ([BLio/matthewnelson/component/base64/Base64$Default;)[B
+	public static final fun encodeBase64ToByteArray ([BLio/matthewnelson/component/base64/Base64$UrlSafe;)[B
+	public static synthetic fun encodeBase64ToByteArray$default ([BLio/matthewnelson/component/base64/Base64$Default;ILjava/lang/Object;)[B
 	public static final fun encodeBase64ToCharArray ([B)[C
-	public static final fun encodeBase64ToCharArray ([BLio/matthewnelson/component/base64/Base64;)[C
-	public static synthetic fun encodeBase64ToCharArray$default ([BLio/matthewnelson/component/base64/Base64;ILjava/lang/Object;)[C
+	public static final fun encodeBase64ToCharArray ([BLio/matthewnelson/component/base64/Base64$Default;)[C
+	public static final fun encodeBase64ToCharArray ([BLio/matthewnelson/component/base64/Base64$UrlSafe;)[C
+	public static synthetic fun encodeBase64ToCharArray$default ([BLio/matthewnelson/component/base64/Base64$Default;ILjava/lang/Object;)[C
 }
 
 public final class io/matthewnelson/encoding/base64/Base64 : io/matthewnelson/encoding/core/EncoderDecoder {

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
@@ -28,6 +28,8 @@
     "PrivatePropertyName",
     "RedundantExplicitType",
     "SpellCheckingInspection",
+    "DEPRECATION",
+    "UNUSED_PARAMETER",
 )
 
 package io.matthewnelson.component.base64
@@ -37,111 +39,236 @@ import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import io.matthewnelson.encoding.core.internal.InternalEncodingApi
 import kotlin.jvm.JvmOverloads
 
-@PublishedApi
-@InternalEncodingApi
-internal val COMPATIBILITY_DEFAULT: io.matthewnelson.encoding.base64.Base64 = Base64 {
-    isLenient = true
-    encodeToUrlSafe = false
-    padEncoded = true
-}
-
-/**
- * This is a derivative work from Okio's Base64 implementation which can
- * be found here:
- *
- *     https://github.com/square/okio/blob/master/okio/src/commonMain/kotlin/okio/-Base64.kt
- *
- * @author original: Alexander Y. Kleymenov
- * @suppress
- * */
+@Deprecated(
+    message = "Replaced by EncoderDecoder. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "Base64",
+        imports = [
+            "io.matthewnelson.encoding.base64.Base64",
+        ]
+    ),
+    level = DeprecationLevel.WARNING,
+)
 public sealed class Base64 {
 
-    /**
-     * Base64 encoding in accordance with RFC 4648 seciton 4
-     * https://www.ietf.org/rfc/rfc4648.html#section-4
-     * */
+    @Deprecated(
+        message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+        replaceWith = ReplaceWith(
+            expression = "Default",
+            imports = [
+                "io.matthewnelson.encoding.base64.Base64.Default",
+            ]
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     public object Default: Base64() {
+        @Deprecated(
+            message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+            replaceWith = ReplaceWith(
+                expression = "Default.CHARS",
+                imports = [
+                    "io.matthewnelson.encoding.base64.Base64.Default",
+                ]
+            ),
+            level = DeprecationLevel.WARNING,
+        )
         public const val CHARS: String = io.matthewnelson.encoding.base64.Base64.Default.CHARS
     }
 
-    /**
-     * Base64UrlSafe encoding in accordance with RFC 4648 section 5
-     * https://www.ietf.org/rfc/rfc4648.html#section-5
-     *
-     * @param [pad] specify whether or not to add padding character '='
-     *  while encoding (true by default).
-     * */
-    public data class UrlSafe @JvmOverloads constructor(val pad: Boolean = true): Base64() {
+    @Deprecated(
+        message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+        replaceWith = ReplaceWith(
+            expression = "Base64.UrlSafe",
+            imports = [
+                "io.matthewnelson.encoding.base64.Base64",
+            ]
+        ),
+        level = DeprecationLevel.WARNING,
+    )
+    public data class UrlSafe @JvmOverloads constructor(
+
+        @Deprecated(
+            message = "Replaced by EncoderDecoders. Use io.matthewnelson.builders.Base64UrlSafe to set",
+            level = DeprecationLevel.WARNING,
+        )
+        val pad: Boolean = true
+    ): Base64() {
 
         public companion object {
+
+            @Deprecated(
+                message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+                replaceWith = ReplaceWith(
+                    expression = "UrlSafe.CHARS",
+                    imports = [
+                        "io.matthewnelson.encoding.base64.Base64.UrlSafe",
+                    ]
+                ),
+                level = DeprecationLevel.WARNING,
+            )
             public const val CHARS: String = io.matthewnelson.encoding.base64.Base64.UrlSafe.CHARS
         }
     }
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base64())",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase64ToArray(): ByteArray? {
-    @OptIn(InternalEncodingApi::class)
-    return decodeToByteArrayOrNull(COMPATIBILITY_DEFAULT)
+    return decodeToByteArrayOrNull(Base64 {
+        isLenient = true
+        encodeToUrlSafe = false // decodes both default and urlsafe
+        padEncoded = true
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.decodeToByteArrayOrNull(Base64())",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArrayOrNull",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 public fun CharArray.decodeBase64ToArray(): ByteArray? {
-    @OptIn(InternalEncodingApi::class)
-    return decodeToByteArrayOrNull(COMPATIBILITY_DEFAULT)
+    return decodeToByteArrayOrNull(Base64 {
+        isLenient = true
+        encodeToUrlSafe = false // decodes both default and urlsafe
+        padEncoded = true
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToString(Base64())",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
-public inline fun ByteArray.encodeBase64(base64: Base64 = Base64.Default): String {
-    @OptIn(InternalEncodingApi::class)
-    return when (base64) {
-        is Base64.Default -> {
-            encodeToString(COMPATIBILITY_DEFAULT)
-        }
-        is Base64.UrlSafe -> {
-            encodeToString(Base64 {
-                isLenient = true
-                encodeToUrlSafe = true
-                padEncoded = base64.pad
-            })
-        }
-    }
+public inline fun ByteArray.encodeBase64(base64: Base64.Default = Base64.Default): String {
+    return encodeToString(Base64 {
+        isLenient = true
+        encodeToUrlSafe = false
+        padEncoded = true
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToString(Base64 { encodeToUrlSafe = true; padEncoded = true/false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToString",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun ByteArray.encodeBase64(base64: Base64.UrlSafe): String {
+    return encodeToString(Base64 {
+        isLenient = true
+        encodeToUrlSafe = true
+        padEncoded = base64.pad
+    })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToCharArray(Base64())",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
-public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64 = Base64.Default): CharArray {
-    @OptIn(InternalEncodingApi::class)
-    return when (base64) {
-        is Base64.Default -> {
-            encodeToCharArray(COMPATIBILITY_DEFAULT)
-        }
-        is Base64.UrlSafe -> {
-            encodeToCharArray(Base64 {
-                isLenient = true
-                encodeToUrlSafe = true
-                padEncoded = base64.pad
-            })
-        }
-    }
+public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.Default = Base64.Default): CharArray {
+    return encodeToCharArray(Base64 {
+        isLenient = true
+        encodeToUrlSafe = false
+        padEncoded = true
+    })
 }
 
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToCharArray(Base64 { encodeToUrlSafe = true; padEncoded = true/false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToCharArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+@Suppress("NOTHING_TO_INLINE")
+public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.UrlSafe): CharArray {
+    return encodeToCharArray(Base64 {
+        isLenient = true
+        encodeToUrlSafe = true
+        padEncoded = base64.pad
+    })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToByteArray(Base64())",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
 @JvmOverloads
-public fun ByteArray.encodeBase64ToByteArray(base64: Base64 = Base64.Default): ByteArray {
-    @OptIn(InternalEncodingApi::class)
-    return when (base64) {
-        is Base64.Default -> {
-            encodeToByteArray(COMPATIBILITY_DEFAULT)
-        }
-        is Base64.UrlSafe -> {
-            encodeToByteArray(Base64 {
-                isLenient = true
-                encodeToUrlSafe = true
-                padEncoded = base64.pad
-            })
-        }
-    }
+public fun ByteArray.encodeBase64ToByteArray(base64: Base64.Default = Base64.Default): ByteArray {
+    return encodeToByteArray(Base64 {
+        isLenient = true
+        encodeToUrlSafe = false
+        padEncoded = true
+    })
+}
+
+@Deprecated(
+    message = "Replaced by EncoderDecoders. Will be removed in future versions.",
+    replaceWith = ReplaceWith(
+        expression = "this.encodeToByteArray(Base64 { encodeToUrlSafe = true; padEncoded = true/false })",
+        imports = [
+            "io.matthewnelson.encoding.builders.Base64",
+            "io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray",
+        ],
+    ),
+    level = DeprecationLevel.WARNING,
+)
+public fun ByteArray.encodeBase64ToByteArray(base64: Base64.UrlSafe): ByteArray {
+    return encodeToByteArray(Base64 {
+        isLenient = true
+        encodeToUrlSafe = true
+        padEncoded = base64.pad
+    })
 }

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
@@ -90,7 +90,7 @@ public sealed class Base64 {
     public data class UrlSafe @JvmOverloads constructor(
 
         @Deprecated(
-            message = "Replaced by EncoderDecoders. Use io.matthewnelson.builders.Base64UrlSafe to set",
+            message = "Replaced by EncoderDecoders. Use io.matthewnelson.builders.Base64 { encodeToUrlSafe = true; padEncoded = true/false } to set",
             level = DeprecationLevel.WARNING,
         )
         val pad: Boolean = true

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -60,6 +60,11 @@ import kotlin.jvm.JvmSynthetic
  * @see [Default.CHARS]
  * @see [UrlSafe.CHARS]
  * @see [EncoderDecoder]
+ * @see [Decoder.decodeToByteArray]
+ * @see [Decoder.decodeToByteArrayOrNull]
+ * @see [Encoder.encodeToString]
+ * @see [Encoder.encodeToCharArray]
+ * @see [Encoder.encodeToByteArray]
  * */
 @OptIn(ExperimentalEncodingApi::class, InternalEncodingApi::class)
 public class Base64(config: Base64.Config): EncoderDecoder(config) {

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64DefaultUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64DefaultUnitTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("SpellCheckingInspection", "DEPRECATION")
+
 package io.matthewnelson.component.encoding.base64
 
 import io.matthewnelson.component.base64.Base64

--- a/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64UrlSafeUnitTest.kt
+++ b/library/encoding-base64/src/commonTest/kotlin/io/matthewnelson/component/encoding/base64/Base64UrlSafeUnitTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("SpellCheckingInspection", "DEPRECATION")
+
 package io.matthewnelson.component.encoding.base64
 
 import io.matthewnelson.component.base64.Base64


### PR DESCRIPTION
Closes #43 

This PR deprecates all old extension functions and related classes for `base16`, `base32`, and `base64` modules.