### PR TITLE
Change `EncoderDecoder.Feed.config` visibility from `private` to `public`

### DIFF
--- a/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
+++ b/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
@@ -115,11 +115,11 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
 
         // Read the encoded data from the file
         val sb = StringBuilder()
-        file.inputStream().use { stream ->
+        file.inputStream().use { iStream ->
 
             @OptIn(ExperimentalEncodingApi::class)
             base64DefaultEncoderDecoder.newDecoderFeed { decodedByte ->
-                // Update the StringBuffer with every decoded
+                // Update the StringBuilder with every decoded
                 // byte that is pushed out of the feed.
                 sb.append(decodedByte.toInt().toChar())
             }.use { feed ->
@@ -135,7 +135,7 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
 
                 val buffer = ByteArray(size)
                 while (true) {
-                    val read = stream.read(buffer)
+                    val read = iStream.read(buffer)
                     if (read == -1) break
 
                     for (i in 0 until read) {

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -76,6 +76,7 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Feed {
 	public final fun close ()V
 	public final fun doFinal ()V
 	protected abstract fun doFinalProtected ()V
+	public final fun getConfig ()Lio/matthewnelson/encoding/core/EncoderDecoder$Config;
 	public final fun isClosed ()Z
 	public final fun update (B)V
 	protected abstract fun updateProtected (B)V

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -273,7 +273,7 @@ constructor(config: Config): Encoder(config) {
      * @see [Encoder.Feed]
      * @see [Decoder.Feed]
      * */
-    public sealed class Feed(private val config: Config) {
+    public sealed class Feed(public val config: Config) {
         @get:JvmName("isClosed")
         public var isClosed: Boolean = false
             private set


### PR DESCRIPTION
Closes #69 

Also adds an example of streaming encoded data to, and decoded data from a `File` in the sample `:app`