### PR TITLE
Add Unit Tests for `encoding-core`

### DIFF
--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -89,10 +89,11 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
          * returns the encoded data in the form of a [String].
          *
          * @throws [EncodingSizeException] if the encoded output
-         *   exceeds [Int.MAX_VALUE]. This is not applicable for
+         *   exceeds [Int.MAX_VALUE]. This is **not applicable** for
          *   most encoding specifications as the majority compress
          *   data, but is something that can occur with Base16 (hex)
-         *   which produces 2 characters for every 1 byte of input.
+         *   as it produces 2 characters of output for every 1 byte
+         *   of input.
          * */
         @JvmStatic
         @Throws(EncodingSizeException::class)
@@ -100,8 +101,8 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
             return encoder.encodeOutSizeOrFail(size) { outSize ->
                 val sb = StringBuilder(outSize)
 
-                encoder.encode(this) { byte ->
-                    sb.append(byte.char)
+                encoder.encode(this) { encodedByte ->
+                    sb.append(encodedByte.char)
                 }
 
                 sb.toString()
@@ -113,10 +114,11 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
          * returns the encoded data in the form of a [CharArray].
          *
          * @throws [EncodingSizeException] if the encoded output
-         *   exceeds [Int.MAX_VALUE]. This is not applicable for
+         *   exceeds [Int.MAX_VALUE]. This is **not applicable** for
          *   most encoding specifications as the majority compress
          *   data, but is something that can occur with Base16 (hex)
-         *   which produces 2 characters for every 1 byte of input.
+         *   as it produces 2 characters of output for every 1 byte
+         *   of input.
          * */
         @JvmStatic
         @Throws(EncodingSizeException::class)
@@ -125,8 +127,8 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
                 val ca = CharArray(outSize)
 
                 var i = 0
-                encoder.encode(this) { byte ->
-                    ca[i++] = byte.char
+                encoder.encode(this) { encodedByte ->
+                    ca[i++] = encodedByte.char
                 }
 
                 ca
@@ -138,10 +140,11 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
          * returns the encoded data in the form of a [ByteArray].
          *
          * @throws [EncodingSizeException] if the encoded output
-         *   exceeds [Int.MAX_VALUE]. This is not applicable for
+         *   exceeds [Int.MAX_VALUE]. This is **not applicable** for
          *   most encoding specifications as the majority compress
          *   data, but is something that can occur with Base16 (hex)
-         *   which produces 2 characters for every 1 byte of input.
+         *   as it produces 2 characters of output for every 1 byte
+         *   of input.
          * */
         @JvmStatic
         @Throws(EncodingSizeException::class)
@@ -150,8 +153,8 @@ public sealed class Encoder(config: EncoderDecoder.Config): Decoder(config) {
                 val ba = ByteArray(outSize)
 
                 var i = 0
-                encoder.encode(this) { byte ->
-                    ba[i++] = byte
+                encoder.encode(this) { encodedByte ->
+                    ba[i++] = encodedByte
                 }
 
                 ba

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/internal/-EncoderDecoder.kt
@@ -83,13 +83,13 @@ internal inline fun <T: Any> Encoder.encodeOutSizeOrFail(
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(ExperimentalEncodingApi::class)
 internal inline fun Encoder.encode(
-    bytes: ByteArray,
+    data: ByteArray,
     out: OutFeed,
 ) {
-    if (bytes.isEmpty()) return
+    if (data.isEmpty()) return
 
     newEncoderFeed(out).use { feed ->
-        for (byte in bytes) {
+        for (byte in data) {
             feed.consume(byte)
         }
     }

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core
+
+import io.matthewnelson.encoding.core.helpers.TestConfig
+import io.matthewnelson.encoding.core.helpers.TestEncoderDecoder
+import io.matthewnelson.encoding.core.util.byte
+import kotlin.test.*
+
+@OptIn(ExperimentalEncodingApi::class)
+class EncoderDecoderFeedUnitTest {
+
+    @Test
+    fun givenFeed_whenDoFinalIsCalled_thenFeedCloses() {
+        val feed = TestEncoderDecoder(TestConfig(isLenient = true)).newDecoderFeed { byte ->
+            assertEquals(Byte.MIN_VALUE, byte)
+        }
+
+        assertFalse(feed.isClosed)
+        feed.doFinal()
+        assertTrue(feed.isClosed)
+    }
+
+    @Test
+    fun givenFeed_whenClosed_thenConsumeAndDoFinalThrowException() {
+        val feed = TestEncoderDecoder(TestConfig()).newDecoderFeed {}
+
+        feed.close()
+
+        try {
+            feed.consume(5)
+            fail()
+        } catch (_: EncodingException) {
+            // pass
+        }
+
+        try {
+            feed.doFinal()
+            fail()
+        } catch (_: EncodingException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun givenFeed_whenConsumeThrowsException_thenFeedClosesAutomaticallyBeforeThrowing() {
+        val feed = TestEncoderDecoder(TestConfig()).newDecoderFeed {
+            throw IllegalStateException("")
+        }
+
+        try {
+            feed.consume(5)
+            fail()
+        } catch (_: IllegalStateException) {
+            assertTrue(feed.isClosed)
+        }
+    }
+
+    @Test
+    fun givenDecoderFeed_whenIsLenientTrue_thenSpacesAndNewLinesAreNotSubmitted() {
+        var out: Byte = 0
+        val feed = TestEncoderDecoder(TestConfig(isLenient = true)).newDecoderFeed { byte ->
+            out = byte
+        }
+
+        listOf(
+            ' ',
+            '\n',
+            '\r',
+            '\t'
+        ).forEach { char ->
+            feed.consume(char.byte)
+            assertEquals(0, out)
+        }
+
+        feed.consume('g'.byte)
+        assertEquals(Byte.MAX_VALUE, out)
+    }
+
+    @Test
+    fun givenDecoderFeed_whenIsLenientFalse_thenSpaceOrNewLinesThrowExceptionAndCloseFeed() {
+        listOf(
+            ' ',
+            '\n',
+            '\r',
+            '\t'
+        ).forEach { char ->
+            val feed = TestEncoderDecoder(TestConfig(isLenient = false)).newDecoderFeed {}
+
+            try {
+                feed.consume(char.byte)
+                fail()
+            } catch (_: EncodingException) {
+                assertTrue(feed.isClosed)
+            }
+        }
+    }
+
+    @Test
+    fun givenDecoderFeed_whenIsLenientNull_thenSpaceOrNewLinesArePassed() {
+        var out: Byte = 0
+        val feed = TestEncoderDecoder(TestConfig(isLenient = null)).newDecoderFeed { byte ->
+            out = byte
+        }
+
+        listOf(
+            ' ',
+            '\n',
+            '\r',
+            '\t'
+        ).forEach { char ->
+            assertEquals(0, out)
+            feed.consume(char.byte)
+            assertEquals(Byte.MAX_VALUE, out)
+
+            // Reset for next
+            out = 0
+        }
+    }
+
+    @Test
+    fun givenDecoderFeed_whenPaddingExpressedInConfig_thenPaddingIsNotSubmitted() {
+        val feed = TestEncoderDecoder(TestConfig(paddingByte = '='.byte)).newDecoderFeed {
+            fail()
+        }
+
+        feed.consume('='.byte)
+    }
+
+    @Test
+    fun givenDecoderFeed_whenPaddingExpressedInConfig_thenThrowsExceptionAndClosesIfConsumingNonPaddingAfterSeeingPadding() {
+        val feed = TestEncoderDecoder(TestConfig(isLenient = true, paddingByte = '='.byte)).newDecoderFeed {
+            fail()
+        }
+
+        feed.consume('='.byte)
+        feed.consume('='.byte)
+
+        // Whitespace after padding should simply be
+        // ignored if isLenient is true, as per usual
+        feed.consume(' '.byte)
+
+        try {
+            feed.consume('g'.byte)
+            fail()
+        } catch (_: EncodingException) {
+            assertTrue(feed.isClosed)
+        }
+    }
+}

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestEncoderDecoder.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestEncoderDecoder.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core.helpers
+
+import io.matthewnelson.encoding.core.*
+
+@OptIn(ExperimentalEncodingApi::class)
+class TestEncoderDecoder(config: TestConfig): EncoderDecoder(config) {
+    override fun name(): String = "Test"
+
+    @ExperimentalEncodingApi
+    override fun newEncoderFeed(out: OutFeed): Encoder.Feed {
+        return object : Encoder.Feed() {
+            override fun consumeProtected(input: Byte) { out.output(Byte.MAX_VALUE) }
+            override fun doFinalProtected() { out.output(Byte.MIN_VALUE) }
+        }
+    }
+
+    @ExperimentalEncodingApi
+    override fun newDecoderFeed(out: OutFeed): Decoder.Feed {
+        return object : Decoder.Feed() {
+            override fun consumeProtected(input: Byte) { out.output(Byte.MAX_VALUE) }
+            override fun doFinalProtected() { out.output(Byte.MIN_VALUE) }
+        }
+    }
+}

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/buffer/FeedBufferUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/util/buffer/FeedBufferUnitTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2023 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.encoding.core.util.buffer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class FeedBufferUnitTest {
+
+    private inner class TestBuffer(
+        blockSize: Int,
+        flush: Flush<Byte> = Flush { _ -> },
+        finalize: Finalize<Byte> = Finalize { _, _ -> },
+    ): EncodingBuffer(
+        blockSize, flush, finalize
+    )
+
+    @Test
+    fun givenFeedBuffer_whenBlockSizeLessThanOrEqualToZero_thenThrowsException() {
+        try {
+            TestBuffer(blockSize = 0)
+            fail()
+        } catch (_: IllegalArgumentException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun givenBlockSize_whenBufferFilled_thenFlushIsInvoked() {
+        for (i in 1..10) {
+            var invokedCount = 0
+            val buffer = TestBuffer(i, flush = { buffer ->
+                invokedCount++
+                assertEquals(i, buffer.size)
+                for (byte in buffer) {
+                    assertEquals(i.toByte(), byte)
+                }
+            })
+
+            for (j in 0 until i) {
+                buffer.update(i.toByte())
+            }
+
+            assertEquals(1, invokedCount)
+        }
+    }
+
+    @Test
+    fun givenFeedBuffer_whenFinalizeIsCalled_thenExcessBufferedAreClearedBeforeFinalize() {
+        val buffer = TestBuffer(15, finalize = { modulus, buffer ->
+            assertEquals(5, modulus)
+            assertEquals(15, buffer.size)
+
+            for ((i, v) in (5 downTo 1).withIndex()) {
+                assertEquals(v.toByte(), buffer[i])
+            }
+
+            for (i in 5..buffer.lastIndex) {
+                assertEquals(0, buffer[i])
+            }
+        })
+
+        // Fill the buffer entirely
+        repeat(15) {
+            buffer.update(20)
+        }
+
+        // Update with 5 more
+        for (i in 5 downTo 1) {
+            buffer.update(i.toByte())
+        }
+
+        buffer.finalize()
+    }
+
+    @Test
+    fun givenFeedBuffer_whenFinalizeIsCalled_thenBufferIsClearedAfterInvocation() {
+        var invokedCount = 0
+
+        val buffer = TestBuffer(5, finalize = { modulus, buffer ->
+            when (invokedCount++) {
+                0 -> {
+                    for (i in 0 until modulus) {
+                        assertEquals(4, buffer[i])
+                    }
+                }
+                1 -> {
+                    for (byte in buffer) {
+                        assertEquals(0, byte)
+                    }
+                }
+                else -> fail()
+            }
+        })
+
+        // Fill it up to just before flush would be invoked
+        repeat(4) {
+            buffer.update(4)
+        }
+
+        // After first invocation, buffered should be cleared
+        buffer.finalize()
+
+        // Calling again will test that what was buffered for
+        // the first finalize call has been cleared post
+        // finalize invocation.
+        buffer.finalize()
+
+        // Ensure it was invoked
+        assertEquals(2, invokedCount)
+    }
+}


### PR DESCRIPTION
This just adds some unit tests for the `encoding-core` functionality now that the API is pretty solidified.