### PR TITLE
Add ability to express line break intervals from config

### DIFF
--- a/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
+++ b/app/src/main/java/io/matthewnelson/component/encoding/app/MainActivity.kt
@@ -27,6 +27,7 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.matthewnelson.encoding.core.ExperimentalEncodingApi
 import io.matthewnelson.encoding.core.use
 import java.io.File
+import java.security.SecureRandom
 
 class MainActivity: AppCompatActivity(R.layout.activity_main) {
 
@@ -35,6 +36,7 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
 
         private val base16EncoderDecoder = Base16 {
             isLenient = false
+            lineBreakInterval = 64
             encodeToLowercase = true
         }
 
@@ -47,24 +49,28 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
 
         private val base32DefaultEncoderDecoder = Base32Default {
             isLenient = false
+            lineBreakInterval = 64
             encodeToLowercase = true
             padEncoded = false
         }
 
         private val base32HexEncoderDecoder = Base32Hex {
             isLenient = false
+            lineBreakInterval = 64
             encodeToLowercase = true
             padEncoded = false
         }
 
         private val base64DefaultEncoderDecoder = Base64 {
             isLenient = true
+            lineBreakInterval = 64
             encodeToUrlSafe = false
             padEncoded = true
         }
 
         private val base64UrlSafeEncoderDecoder = Base64 {
             isLenient = false
+            lineBreakInterval = 64
             encodeToUrlSafe = true
             padEncoded = false
         }
@@ -108,10 +114,10 @@ class MainActivity: AppCompatActivity(R.layout.activity_main) {
                 oStream.write(encodedChar.code)
             }.use { feed ->
 
-                HELLO_WORLD.forEach { c ->
-                    // Update the feed with each character
-                    // of Hello World!
-                    feed.consume(c.code.toByte())
+                val random = ByteArray(256)
+                SecureRandom().nextBytes(random)
+                random.forEach { b ->
+                    feed.consume(b)
                 }
             }
         }

--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -20,12 +20,13 @@ public final class io/matthewnelson/encoding/base16/Base16$Companion {
 
 public final class io/matthewnelson/encoding/base16/Base16$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field encodeToLowercase Z
-	public synthetic fun <init> (ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZBZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/builders/Base16ConfigBuilder {
 	public field encodeToLowercase Z
 	public field isLenient Z
+	public field lineBreakInterval B
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Config;)V
 	public final fun build ()Lio/matthewnelson/encoding/base16/Base16$Config;

--- a/library/encoding-base16/api/encoding-base16.api
+++ b/library/encoding-base16/api/encoding-base16.api
@@ -12,7 +12,6 @@ public final class io/matthewnelson/encoding/base16/Base16 : io/matthewnelson/en
 	public static final field Companion Lio/matthewnelson/encoding/base16/Base16$Companion;
 	public fun <init> (Lio/matthewnelson/encoding/base16/Base16$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/Decoder$OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
-	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
 
 public final class io/matthewnelson/encoding/base16/Base16$Companion {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/component/encoding/base16/Base16.kt
@@ -36,10 +36,7 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase16ToArray(): ByteArray? {
-    return decodeToByteArrayOrNull(Base16 {
-        isLenient = true
-        encodeToLowercase = false
-    })
+    return decodeToByteArrayOrNull(Base16())
 }
 
 @Deprecated(
@@ -54,10 +51,7 @@ public inline fun String.decodeBase16ToArray(): ByteArray? {
     level = DeprecationLevel.WARNING,
 )
 public fun CharArray.decodeBase16ToArray(): ByteArray? {
-    return decodeToByteArrayOrNull(Base16 {
-        isLenient = true
-        encodeToLowercase = false
-    })
+    return decodeToByteArrayOrNull(Base16())
 }
 
 @Deprecated(
@@ -73,10 +67,7 @@ public fun CharArray.decodeBase16ToArray(): ByteArray? {
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase16(): String {
-    return encodeToString(Base16 {
-        isLenient = true
-        encodeToLowercase = false
-    })
+    return encodeToString(Base16 { encodeToLowercase = false })
 }
 
 @Deprecated(
@@ -92,10 +83,7 @@ public inline fun ByteArray.encodeBase16(): String {
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase16ToCharArray(): CharArray {
-    return encodeToCharArray(Base16 {
-        isLenient = true
-        encodeToLowercase = false
-    })
+    return encodeToCharArray(Base16 { encodeToLowercase = false })
 }
 
 @Deprecated(
@@ -110,8 +98,5 @@ public inline fun ByteArray.encodeBase16ToCharArray(): CharArray {
     level = DeprecationLevel.WARNING,
 )
 public fun ByteArray.encodeBase16ToByteArray(): ByteArray {
-    return encodeToByteArray(Base16 {
-        isLenient = true
-        encodeToLowercase = false
-    })
+    return encodeToByteArray(Base16 { encodeToLowercase = false })
 }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -34,14 +34,14 @@ import kotlin.jvm.JvmSynthetic
  *
  *     val base16 = Base16 {
  *         isLenient = true
- *         acceptLowercase = true
- *         encodeToLowercase = false
+ *         lineBreakInterval = 64
+ *         encodeToLowercase = true
  *     }
  *
  *     val text = "Hello World!"
  *     val bytes = text.encodeToByteArray()
  *     val encoded = bytes.encodeToString(base16)
- *     println(encoded) // 48656C6C6F20576F726C6421
+ *     println(encoded) // 48656c6c6f20576f726c6421
  *     val decoded = encoded.decodeToByteArray(base16).decodeToString()
  *     assertEquals(text, decoded)
  *
@@ -69,9 +69,14 @@ public class Base16(config: Base16.Config): EncoderDecoder<Base16.Config>(config
      * */
     public class Config private constructor(
         isLenient: Boolean,
+        lineBreakInterval: Byte,
         @JvmField
         public val encodeToLowercase: Boolean,
-    ): EncoderDecoder.Config(isLenient, paddingChar = null) {
+    ): EncoderDecoder.Config(
+        isLenient = isLenient,
+        lineBreakInterval = lineBreakInterval,
+        paddingChar = null
+    ) {
 
         override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
             return encodedSize / 2L
@@ -103,6 +108,7 @@ public class Base16(config: Base16.Config): EncoderDecoder<Base16.Config>(config
             internal fun from(builder: Base16ConfigBuilder): Config {
                 return Config(
                     isLenient = builder.isLenient,
+                    lineBreakInterval = builder.lineBreakInterval,
                     encodeToLowercase = builder.encodeToLowercase,
                 )
             }

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/base16/Base16.kt
@@ -128,8 +128,7 @@ public class Base16(config: Base16.Config): EncoderDecoder<Base16.Config>(config
         public const val CHARS_LOWER: String = "0123456789abcdef"
     }
 
-    @ExperimentalEncodingApi
-    override fun newEncoderFeed(out: OutFeed): Encoder<Config>.Feed {
+    protected override fun newEncoderFeedProtected(out: OutFeed): Encoder<Config>.Feed {
         return object : Encoder<Config>.Feed() {
 
             private val table = if (config.encodeToLowercase) {

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -87,10 +87,10 @@ public class Base16ConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
-     * For every [lineBreakInterval] of encoded output, a
-     * line break will be inserted.
+     * For every [lineBreakInterval] of encoded data, a
+     * line break will be output.
      *
-     * Will **ONLY** insert line breaks if [isLenient] is
+     * Will **ONLY** output line breaks if [isLenient] is
      * set to **true**.
      *
      * e.g.

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -73,6 +73,7 @@ public class Base16ConfigBuilder {
     public constructor(config: Config?): this() {
         if (config == null) return
         isLenient = config.isLenient ?: true
+        lineBreakInterval = config.lineBreakInterval
         encodeToLowercase = config.encodeToLowercase
     }
 

--- a/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
+++ b/library/encoding-base16/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base16.kt
@@ -87,6 +87,36 @@ public class Base16ConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
+     * For every [lineBreakInterval] of encoded output, a
+     * line break will be inserted.
+     *
+     * Will **ONLY** insert line breaks if [isLenient] is
+     * set to **true**.
+     *
+     * e.g.
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 0
+     *     // 48656C6C6F20576F726C6421
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 16
+     *     // 48656C6C6F20576F
+     *     // 726C6421
+     *
+     *     isLenient = false
+     *     lineBreakInterval = 16
+     *     // 48656C6C6F20576F726C6421
+     *
+     * Enable by setting to a value between 1 and 127, and
+     * setting [isLenient] to true.
+     *
+     * A great value is 64
+     * */
+    @JvmField
+    public var lineBreakInterval: Byte = 0
+
+    /**
      * If true, will output lowercase characters when
      * encoding (against RFC 4648).
      *
@@ -102,6 +132,7 @@ public class Base16ConfigBuilder {
      * */
     public fun strict(): Base16ConfigBuilder {
         isLenient = false
+        lineBreakInterval = 0
         encodeToLowercase = false
         return this
     }

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -69,7 +69,6 @@ public final class io/matthewnelson/encoding/base32/Base32$Crockford : io/matthe
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Crockford$Companion;
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Crockford$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/Decoder$OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
-	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Crockford$Companion {
@@ -88,7 +87,6 @@ public final class io/matthewnelson/encoding/base32/Base32$Default : io/matthewn
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Default$Companion;
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/Decoder$OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
-	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Default$Companion {
@@ -106,7 +104,6 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelso
 	public static final field Companion Lio/matthewnelson/encoding/base32/Base32$Hex$Companion;
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/Decoder$OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
-	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Hex$Companion {

--- a/library/encoding-base32/api/encoding-base32.api
+++ b/library/encoding-base32/api/encoding-base32.api
@@ -97,7 +97,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Default$Companion {
 public final class io/matthewnelson/encoding/base32/Base32$Default$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
-	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZBZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/base32/Base32$Hex : io/matthewnelson/encoding/base32/Base32 {
@@ -115,7 +115,7 @@ public final class io/matthewnelson/encoding/base32/Base32$Hex$Companion {
 public final class io/matthewnelson/encoding/base32/Base32$Hex$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field encodeToLowercase Z
 	public final field padEncoded Z
-	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZBZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuilder {
@@ -133,6 +133,7 @@ public final class io/matthewnelson/encoding/builders/Base32CrockfordConfigBuild
 public final class io/matthewnelson/encoding/builders/Base32DefaultConfigBuilder {
 	public field encodeToLowercase Z
 	public field isLenient Z
+	public field lineBreakInterval B
 	public field padEncoded Z
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Default$Config;)V
@@ -143,6 +144,7 @@ public final class io/matthewnelson/encoding/builders/Base32DefaultConfigBuilder
 public final class io/matthewnelson/encoding/builders/Base32HexConfigBuilder {
 	public field encodeToLowercase Z
 	public field isLenient Z
+	public field lineBreakInterval B
 	public field padEncoded Z
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base32/Base32$Hex$Config;)V

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/component/encoding/base32/Base32.kt
@@ -170,7 +170,7 @@ public sealed class Base32 {
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase32ToArray(base32: Base32.Default = Base32.Default): ByteArray? {
-    return decodeToByteArrayOrNull(Base32Default { encodeToLowercase = false })
+    return decodeToByteArrayOrNull(Base32Default())
 }
 
 @Deprecated(
@@ -186,7 +186,7 @@ public inline fun String.decodeBase32ToArray(base32: Base32.Default = Base32.Def
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
-    return decodeToByteArrayOrNull(Base32Hex { encodeToLowercase = false })
+    return decodeToByteArrayOrNull(Base32Hex())
 }
 
 @Deprecated(
@@ -202,12 +202,7 @@ public inline fun String.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase32ToArray(base32: Base32.Crockford): ByteArray? {
-    return decodeToByteArrayOrNull(Base32Crockford {
-        isLenient = true
-        encodeToLowercase = false
-        hyphenInterval = 0
-        checkSymbol(base32.checkSymbol)
-    })
+    return decodeToByteArrayOrNull(Base32Crockford { checkSymbol(base32.checkSymbol) })
 }
 
 @Deprecated(
@@ -223,7 +218,7 @@ public inline fun String.decodeBase32ToArray(base32: Base32.Crockford): ByteArra
 )
 @JvmOverloads
 public fun CharArray.decodeBase32ToArray(base32: Base32.Default = Base32.Default): ByteArray? {
-    return decodeToByteArrayOrNull(Base32Default { encodeToLowercase = false })
+    return decodeToByteArrayOrNull(Base32Default())
 }
 
 @Deprecated(
@@ -238,7 +233,7 @@ public fun CharArray.decodeBase32ToArray(base32: Base32.Default = Base32.Default
     level = DeprecationLevel.WARNING,
 )
 public fun CharArray.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
-    return decodeToByteArrayOrNull(Base32Hex { encodeToLowercase = false })
+    return decodeToByteArrayOrNull(Base32Hex())
 }
 
 @Deprecated(
@@ -253,12 +248,7 @@ public fun CharArray.decodeBase32ToArray(base32: Base32.Hex): ByteArray? {
     level = DeprecationLevel.WARNING,
 )
 public fun CharArray.decodeBase32ToArray(base32: Base32.Crockford): ByteArray? {
-    return decodeToByteArrayOrNull(Base32Crockford {
-        isLenient = true
-        encodeToLowercase = false
-        hyphenInterval = 0
-        checkSymbol(base32.checkSymbol)
-    })
+    return decodeToByteArrayOrNull(Base32Crockford { checkSymbol(base32.checkSymbol) })
 }
 
 @Deprecated(
@@ -308,9 +298,7 @@ public inline fun ByteArray.encodeBase32(base32: Base32.Hex): String {
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase32(base32: Base32.Crockford): String {
     return encodeToString(Base32Crockford {
-        isLenient = true
         encodeToLowercase = false
-        hyphenInterval = 0
         checkSymbol(base32.checkSymbol)
     })
 }
@@ -362,9 +350,7 @@ public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Hex): CharArr
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase32ToCharArray(base32: Base32.Crockford): CharArray {
     return encodeToCharArray(Base32Crockford {
-        isLenient = true
         encodeToLowercase = false
-        hyphenInterval = 0
         checkSymbol(base32.checkSymbol)
     })
 }
@@ -413,9 +399,7 @@ public fun ByteArray.encodeBase32ToByteArray(base32: Base32.Hex): ByteArray {
 )
 public fun ByteArray.encodeBase32ToByteArray(base32: Base32.Crockford): ByteArray {
     return encodeToByteArray(Base32Crockford {
-        isLenient = true
         encodeToLowercase = false
-        hyphenInterval = 0
         checkSymbol(base32.checkSymbol)
     })
 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -324,8 +324,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
         }
 
-        @ExperimentalEncodingApi
-        override fun newEncoderFeed(out: Encoder.OutFeed): Encoder<Crockford.Config>.Feed {
+        protected override fun newEncoderFeedProtected(out: Encoder.OutFeed): Encoder<Crockford.Config>.Feed {
             return object : Encoder<Crockford.Config>.Feed() {
 
                 private var outCount: Byte = 0
@@ -516,8 +515,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
         }
 
-        @ExperimentalEncodingApi
-        override fun newEncoderFeed(out: OutFeed): Encoder<Default.Config>.Feed {
+        protected override fun newEncoderFeedProtected(out: OutFeed): Encoder<Default.Config>.Feed {
             return object : Encoder<Default.Config>.Feed() {
 
                 private val buffer = EncodingBuffer(
@@ -686,8 +684,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             }
         }
 
-        @ExperimentalEncodingApi
-        override fun newEncoderFeed(out: OutFeed): Encoder<Hex.Config>.Feed {
+        protected override fun newEncoderFeedProtected(out: OutFeed): Encoder<Hex.Config>.Feed {
             return object : Encoder<Hex.Config>.Feed() {
 
                 private val buffer = EncodingBuffer(

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -86,7 +86,11 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
             public val hyphenInterval: Byte,
             @JvmField
             public val checkSymbol: Char?,
-        ): EncoderDecoder.Config(isLenient, paddingChar = null) {
+        ): EncoderDecoder.Config(
+            isLenient = isLenient,
+            lineBreakInterval = 0,
+            paddingChar = null,
+        ) {
 
             override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
                 return encodedSize.decodeOutMaxSize()
@@ -382,7 +386,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
      *
      *     val base32Default = Base32Default {
      *         isLenient = true
-     *         acceptLowercase = true
+     *         lineBreakInterval = 64
      *         encodeToLowercase = false
      *         padEncoded = true
      *     }
@@ -412,11 +416,16 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
          * */
         public class Config private constructor(
             isLenient: Boolean,
+            lineBreakInterval: Byte,
             @JvmField
             public val encodeToLowercase: Boolean,
             @JvmField
             public val padEncoded: Boolean,
-        ): EncoderDecoder.Config(isLenient, paddingChar = '=') {
+        ): EncoderDecoder.Config(
+            isLenient = isLenient,
+            lineBreakInterval = lineBreakInterval,
+            paddingChar = '=',
+        ) {
 
             override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
                 return encodedSize.decodeOutMaxSize()
@@ -447,6 +456,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
                 internal fun from(builder: Base32DefaultConfigBuilder): Config {
                     return Config(
                         isLenient = builder.isLenient,
+                        lineBreakInterval = builder.lineBreakInterval,
                         encodeToLowercase = builder.encodeToLowercase,
                         padEncoded = builder.padEncoded,
                     )
@@ -547,7 +557,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
      *
      *     val base32Hex = Base32Hex {
      *         isLenient = true
-     *         acceptLowercase = true
+     *         lineBreakInterval = 64
      *         encodeToLowercase = false
      *         padEncoded = true
      *     }
@@ -577,11 +587,16 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
          * */
         public class Config private constructor(
             isLenient: Boolean,
+            lineBreakInterval: Byte,
             @JvmField
             public val encodeToLowercase: Boolean,
             @JvmField
             public val padEncoded: Boolean,
-        ): EncoderDecoder.Config(isLenient, paddingChar = '=') {
+        ): EncoderDecoder.Config(
+            isLenient = isLenient,
+            lineBreakInterval = lineBreakInterval,
+            paddingChar = '=',
+        ) {
 
             override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
                 return encodedSize.decodeOutMaxSize()
@@ -611,6 +626,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
                 internal fun from(builder: Base32HexConfigBuilder): Config {
                     return Config(
                         isLenient = builder.isLenient,
+                        lineBreakInterval = builder.lineBreakInterval,
                         encodeToLowercase = builder.encodeToLowercase,
                         padEncoded = builder.padEncoded,
                     )

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/base32/Base32.kt
@@ -184,7 +184,7 @@ public sealed class Base32<C: EncoderDecoder.Config>(config: C): EncoderDecoder<
                     return Config(
                         isLenient = builder.isLenient,
                         encodeToLowercase = builder.encodeToLowercase,
-                        hyphenInterval = builder.hyphenInterval,
+                        hyphenInterval = if (builder.hyphenInterval > 0) builder.hyphenInterval else 0,
                         checkSymbol = builder.checkSymbol
                     )
                 }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -267,10 +267,10 @@ public class Base32DefaultConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
-     * For every [lineBreakInterval] of encoded output, a
-     * line break will be inserted.
+     * For every [lineBreakInterval] of encoded data, a
+     * line break will be output.
      *
-     * Will **ONLY** insert line breaks if [isLenient] is
+     * Will **ONLY** output line breaks if [isLenient] is
      * set to **true**.
      *
      * e.g.
@@ -361,10 +361,10 @@ public class Base32HexConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
-     * For every [lineBreakInterval] of encoded output, a
-     * line break will be inserted.
+     * For every [lineBreakInterval] of encoded data, a
+     * line break will be output.
      *
-     * Will **ONLY** insert line breaks if [isLenient] is
+     * Will **ONLY** output line breaks if [isLenient] is
      * set to **true**.
      *
      * e.g.

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -252,6 +252,7 @@ public class Base32DefaultConfigBuilder {
     public constructor(config: Base32.Default.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient ?: true
+        lineBreakInterval = config.lineBreakInterval
         encodeToLowercase = config.encodeToLowercase
         padEncoded = config.padEncoded
     }
@@ -346,6 +347,7 @@ public class Base32HexConfigBuilder {
     public constructor(config: Base32.Hex.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient ?: true
+        lineBreakInterval = config.lineBreakInterval
         encodeToLowercase = config.encodeToLowercase
         padEncoded = config.padEncoded
     }

--- a/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
+++ b/library/encoding-base32/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base32.kt
@@ -173,7 +173,7 @@ public class Base32CrockfordConfigBuilder {
     public var encodeToLowercase: Boolean = true
 
     /**
-     * For every [hyphenInterval] of decoded output, a
+     * For every [hyphenInterval] of encoded output, a
      * hyphen ("-") will be inserted.
      *
      * e.g.
@@ -267,6 +267,36 @@ public class Base32DefaultConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
+     * For every [lineBreakInterval] of encoded output, a
+     * line break will be inserted.
+     *
+     * Will **ONLY** insert line breaks if [isLenient] is
+     * set to **true**.
+     *
+     * e.g.
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 0
+     *     // JBSWY3DPEBLW64TMMQQQ====
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 16
+     *     // JBSWY3DPEBLW64TM
+     *     // MQQQ====
+     *
+     *     isLenient = false
+     *     lineBreakInterval = 16
+     *     // JBSWY3DPEBLW64TMMQQQ====
+     *
+     * Enable by setting to a value between 1 and 127, and
+     * setting [isLenient] to true.
+     *
+     * A great value is 64
+     * */
+    @JvmField
+    public var lineBreakInterval: Byte = 0
+
+    /**
      * If true, will output lowercase characters when
      * encoding (against RFC 4648).
      *
@@ -292,6 +322,7 @@ public class Base32DefaultConfigBuilder {
      * */
     public fun strict(): Base32DefaultConfigBuilder {
         isLenient = false
+        lineBreakInterval = 0
         encodeToLowercase = false
         padEncoded = true
         return this
@@ -330,6 +361,36 @@ public class Base32HexConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
+     * For every [lineBreakInterval] of encoded output, a
+     * line break will be inserted.
+     *
+     * Will **ONLY** insert line breaks if [isLenient] is
+     * set to **true**.
+     *
+     * e.g.
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 0
+     *     // 91IMOR3F41BMUSJCCGGG====
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 16
+     *     // 91IMOR3F41BMUSJC
+     *     // CGGG====
+     *
+     *     isLenient = false
+     *     lineBreakInterval = 16
+     *     // 91IMOR3F41BMUSJCCGGG====
+     *
+     * Enable by setting to a value between 1 and 127, and
+     * setting [isLenient] to true.
+     *
+     * A great value is 64
+     * */
+    @JvmField
+    public var lineBreakInterval: Byte = 0
+
+    /**
      * If true, will output lowercase characters when
      * encoding (against RFC 4648).
      *
@@ -355,6 +416,7 @@ public class Base32HexConfigBuilder {
      * */
     public fun strict(): Base32HexConfigBuilder {
         isLenient = false
+        lineBreakInterval = 0
         encodeToLowercase = false
         padEncoded = true
         return this

--- a/library/encoding-base64/api/encoding-base64.api
+++ b/library/encoding-base64/api/encoding-base64.api
@@ -50,7 +50,7 @@ public final class io/matthewnelson/encoding/base64/Base64 : io/matthewnelson/en
 public final class io/matthewnelson/encoding/base64/Base64$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public final field encodeToUrlSafe Z
 	public final field padEncoded Z
-	public synthetic fun <init> (ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZBZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/matthewnelson/encoding/base64/Base64$Default {
@@ -74,6 +74,7 @@ public final class io/matthewnelson/encoding/builders/Base64BuildersKt {
 public final class io/matthewnelson/encoding/builders/Base64ConfigBuilder {
 	public field encodeToUrlSafe Z
 	public field isLenient Z
+	public field lineBreakInterval B
 	public field padEncoded Z
 	public fun <init> ()V
 	public fun <init> (Lio/matthewnelson/encoding/base64/Base64$Config;)V

--- a/library/encoding-base64/api/encoding-base64.api
+++ b/library/encoding-base64/api/encoding-base64.api
@@ -44,7 +44,6 @@ public final class io/matthewnelson/component/base64/Base64Kt {
 public final class io/matthewnelson/encoding/base64/Base64 : io/matthewnelson/encoding/core/EncoderDecoder {
 	public fun <init> (Lio/matthewnelson/encoding/base64/Base64$Config;)V
 	public fun newDecoderFeed (Lio/matthewnelson/encoding/core/Decoder$OutFeed;)Lio/matthewnelson/encoding/core/Decoder$Feed;
-	public fun newEncoderFeed (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
 
 public final class io/matthewnelson/encoding/base64/Base64$Config : io/matthewnelson/encoding/core/EncoderDecoder$Config {

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/component/base64/Base64.kt
@@ -126,11 +126,7 @@ public sealed class Base64 {
 )
 @Suppress("NOTHING_TO_INLINE")
 public inline fun String.decodeBase64ToArray(): ByteArray? {
-    return decodeToByteArrayOrNull(Base64 {
-        isLenient = true
-        encodeToUrlSafe = false // decodes both default and urlsafe
-        padEncoded = true
-    })
+    return decodeToByteArrayOrNull(Base64())
 }
 
 @Deprecated(
@@ -145,11 +141,7 @@ public inline fun String.decodeBase64ToArray(): ByteArray? {
     level = DeprecationLevel.WARNING,
 )
 public fun CharArray.decodeBase64ToArray(): ByteArray? {
-    return decodeToByteArrayOrNull(Base64 {
-        isLenient = true
-        encodeToUrlSafe = false // decodes both default and urlsafe
-        padEncoded = true
-    })
+    return decodeToByteArrayOrNull(Base64())
 }
 
 @Deprecated(
@@ -166,11 +158,7 @@ public fun CharArray.decodeBase64ToArray(): ByteArray? {
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64(base64: Base64.Default = Base64.Default): String {
-    return encodeToString(Base64 {
-        isLenient = true
-        encodeToUrlSafe = false
-        padEncoded = true
-    })
+    return encodeToString(Base64())
 }
 
 @Deprecated(
@@ -187,7 +175,6 @@ public inline fun ByteArray.encodeBase64(base64: Base64.Default = Base64.Default
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64(base64: Base64.UrlSafe): String {
     return encodeToString(Base64 {
-        isLenient = true
         encodeToUrlSafe = true
         padEncoded = base64.pad
     })
@@ -207,11 +194,7 @@ public inline fun ByteArray.encodeBase64(base64: Base64.UrlSafe): String {
 @JvmOverloads
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.Default = Base64.Default): CharArray {
-    return encodeToCharArray(Base64 {
-        isLenient = true
-        encodeToUrlSafe = false
-        padEncoded = true
-    })
+    return encodeToCharArray(Base64())
 }
 
 @Deprecated(
@@ -228,7 +211,6 @@ public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.Default = Bas
 @Suppress("NOTHING_TO_INLINE")
 public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.UrlSafe): CharArray {
     return encodeToCharArray(Base64 {
-        isLenient = true
         encodeToUrlSafe = true
         padEncoded = base64.pad
     })
@@ -247,11 +229,7 @@ public inline fun ByteArray.encodeBase64ToCharArray(base64: Base64.UrlSafe): Cha
 )
 @JvmOverloads
 public fun ByteArray.encodeBase64ToByteArray(base64: Base64.Default = Base64.Default): ByteArray {
-    return encodeToByteArray(Base64 {
-        isLenient = true
-        encodeToUrlSafe = false
-        padEncoded = true
-    })
+    return encodeToByteArray(Base64())
 }
 
 @Deprecated(
@@ -267,7 +245,6 @@ public fun ByteArray.encodeBase64ToByteArray(base64: Base64.Default = Base64.Def
 )
 public fun ByteArray.encodeBase64ToByteArray(base64: Base64.UrlSafe): ByteArray {
     return encodeToByteArray(Base64 {
-        isLenient = true
         encodeToUrlSafe = true
         padEncoded = base64.pad
     })

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -194,8 +194,7 @@ public class Base64(config: Base64.Config): EncoderDecoder<Base64.Config>(config
         }
     }
 
-    @ExperimentalEncodingApi
-    override fun newEncoderFeed(out: OutFeed): Encoder<Base64.Config>.Feed {
+    protected override fun newEncoderFeedProtected(out: OutFeed): Encoder<Base64.Config>.Feed {
         return object : Encoder<Base64.Config>.Feed() {
 
             private val buffer = EncodingBuffer(

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/base64/Base64.kt
@@ -39,6 +39,7 @@ import kotlin.jvm.JvmSynthetic
  *
  *     val base64 = Base64 {
  *         isLenient = true
+ *         lineBreakInterval = 64
  *         encodeToUrlSafe = false
  *         padEncoded = true
  *     }
@@ -74,11 +75,16 @@ public class Base64(config: Base64.Config): EncoderDecoder<Base64.Config>(config
      * */
     public class Config private constructor(
         isLenient: Boolean,
+        lineBreakInterval: Byte,
         @JvmField
         public val encodeToUrlSafe: Boolean,
         @JvmField
         public val padEncoded: Boolean,
-    ): EncoderDecoder.Config(isLenient, paddingChar = '=') {
+    ): EncoderDecoder.Config(
+        isLenient = isLenient,
+        lineBreakInterval = lineBreakInterval,
+        paddingChar = '=',
+    ) {
 
         override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
             return (encodedSize * 6L / 8L)
@@ -118,6 +124,7 @@ public class Base64(config: Base64.Config): EncoderDecoder<Base64.Config>(config
             internal fun from(builder: Base64ConfigBuilder): Config {
                 return Config(
                     isLenient = builder.isLenient,
+                    lineBreakInterval = builder.lineBreakInterval,
                     encodeToUrlSafe = builder.encodeToUrlSafe,
                     padEncoded = builder.padEncoded,
                 )

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
@@ -84,6 +84,36 @@ public class Base64ConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
+     * For every [lineBreakInterval] of encoded output, a
+     * line break will be inserted.
+     *
+     * Will **ONLY** insert line breaks if [isLenient] is
+     * set to **true**.
+     *
+     * e.g.
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 0
+     *     // SGVsbG8gV29ybGQh
+     *
+     *     isLenient = true
+     *     lineBreakInterval = 10
+     *     // SGVsbG8gV2
+     *     // 9ybGQh
+     *
+     *     isLenient = false
+     *     lineBreakInterval = 10
+     *     // SGVsbG8gV29ybGQh
+     *
+     * Enable by setting to a value between 1 and 127, and
+     * setting [isLenient] to true.
+     *
+     * A great value is 64
+     * */
+    @JvmField
+    public var lineBreakInterval: Byte = 0
+
+    /**
      * If true, will output Base64 UrlSafe characters
      * when encoding.
      *

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
@@ -69,6 +69,7 @@ public class Base64ConfigBuilder {
     public constructor(config: Base64.Config?): this() {
         if (config == null) return
         isLenient = config.isLenient ?: true
+        lineBreakInterval = config.lineBreakInterval
         encodeToUrlSafe = config.encodeToUrlSafe
         padEncoded = config.padEncoded
     }

--- a/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
+++ b/library/encoding-base64/src/commonMain/kotlin/io/matthewnelson/encoding/builders/Base64Builders.kt
@@ -84,10 +84,10 @@ public class Base64ConfigBuilder {
     public var isLenient: Boolean = true
 
     /**
-     * For every [lineBreakInterval] of encoded output, a
-     * line break will be inserted.
+     * For every [lineBreakInterval] of encoded data, a
+     * line break will be output.
      *
-     * Will **ONLY** insert line breaks if [isLenient] is
+     * Will **ONLY** output line breaks if [isLenient] is
      * set to **true**.
      *
      * e.g.

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -73,8 +73,9 @@ public abstract class io/matthewnelson/encoding/core/EncoderDecoder : io/matthew
 public abstract class io/matthewnelson/encoding/core/EncoderDecoder$Config {
 	public static final field Companion Lio/matthewnelson/encoding/core/EncoderDecoder$Config$Companion;
 	public final field isLenient Ljava/lang/Boolean;
+	public final field lineBreakInterval B
 	public final field paddingChar Ljava/lang/Character;
-	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Character;)V
+	public fun <init> (Ljava/lang/Boolean;BLjava/lang/Character;)V
 	public final fun decodeOutMaxSize (J)J
 	public final fun decodeOutMaxSizeOrFail (Lio/matthewnelson/encoding/core/util/DecoderInput;)I
 	protected abstract fun decodeOutMaxSizeOrFailProtected (ILio/matthewnelson/encoding/core/util/DecoderInput;)I

--- a/library/encoding-core/api/encoding-core.api
+++ b/library/encoding-core/api/encoding-core.api
@@ -39,7 +39,8 @@ public abstract class io/matthewnelson/encoding/core/Encoder : io/matthewnelson/
 	public static final fun encodeToByteArray ([BLio/matthewnelson/encoding/core/Encoder;)[B
 	public static final fun encodeToCharArray ([BLio/matthewnelson/encoding/core/Encoder;)[C
 	public static final fun encodeToString ([BLio/matthewnelson/encoding/core/Encoder;)Ljava/lang/String;
-	public abstract fun newEncoderFeed (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+	public final fun newEncoderFeed (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
+	protected abstract fun newEncoderFeedProtected (Lio/matthewnelson/encoding/core/Encoder$OutFeed;)Lio/matthewnelson/encoding/core/Encoder$Feed;
 }
 
 public final class io/matthewnelson/encoding/core/Encoder$Companion {

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/Encoder.kt
@@ -204,7 +204,7 @@ public sealed class Encoder<C: EncoderDecoder.Config>(config: C): Decoder<C>(con
 
     /**
      * A wrapper around [Encoder.OutFeed] to hijack the
-     * output and insert new line characters every at
+     * output and output new line characters at every
      * expressed [interval].
      * */
     private class LineBreakOutFeed(
@@ -219,17 +219,15 @@ public sealed class Encoder<C: EncoderDecoder.Config>(config: C): Decoder<C>(con
         }
 
         private var count: Byte = 0
-        private var outputNewLineOnNext = false
 
         override fun output(encoded: Char) {
-            if (outputNewLineOnNext) {
+            if (count == interval) {
                 out.output('\n')
                 count = 0
-                outputNewLineOnNext = false
             }
 
             out.output(encoded)
-            outputNewLineOnNext = ++count == interval
+            count++
         }
     }
 }

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -47,6 +47,9 @@ constructor(config: C): Encoder<C>(config) {
      *   [EncodingException] will be thrown when encountering those
      *   characters. See [isSpaceOrNewLine]. If null, those bytes
      *   are sent to the [EncoderDecoder].
+     * @param [lineBreakInterval] If greater than 0 and [isLenient]
+     *   is not **false** (i.e. null or true), line breaks will be
+     *   output at the expressed [lineBreakInterval].
      * @param [paddingChar] The byte used when padding the output for
      *   the given encoding; NOT "if padding should be
      *   used". (e.g. '='.code.toByte()).
@@ -59,9 +62,17 @@ constructor(config: C): Encoder<C>(config) {
     constructor(
         @JvmField
         public val isLenient: Boolean?,
+        lineBreakInterval: Byte,
         @JvmField
         public val paddingChar: Char?,
     ) {
+
+        @JvmField
+        public val lineBreakInterval: Byte = if (isLenient != false && lineBreakInterval > 0) {
+            lineBreakInterval
+        } else {
+            0
+        }
 
         /**
          * Calculates and returns the size of the output after encoding
@@ -249,6 +260,9 @@ constructor(config: C): Encoder<C>(config) {
                 appendLine()
                 append("    isLenient: ")
                 append(isLenient)
+                appendLine()
+                append("    lineBreakInterval: ")
+                append(lineBreakInterval)
                 appendLine()
                 append("    paddingChar: ")
                 append(paddingChar)

--- a/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
+++ b/library/encoding-core/src/commonMain/kotlin/io/matthewnelson/encoding/core/EncoderDecoder.kt
@@ -48,7 +48,7 @@ constructor(config: C): Encoder<C>(config) {
      *   characters. See [isSpaceOrNewLine]. If null, those bytes
      *   are sent to the [EncoderDecoder].
      * @param [lineBreakInterval] If greater than 0 and [isLenient]
-     *   is not **false** (i.e. null or true), line breaks will be
+     *   is not **false** (i.e. is null or true), line breaks will be
      *   output at the expressed [lineBreakInterval].
      * @param [paddingChar] The byte used when padding the output for
      *   the given encoding; NOT "if padding should be
@@ -94,10 +94,27 @@ constructor(config: C): Encoder<C>(config) {
             // return early
             if (unEncodedSize == 0L) return 0L
 
-            val outSize = encodeOutSizeProtected(unEncodedSize)
+            var outSize = encodeOutSizeProtected(unEncodedSize)
             if (outSize < 0L) {
                 throw calculatedOutputNegativeEncodingSizeException(outSize)
             }
+
+            if (lineBreakInterval > 0) {
+                var lineBreakCount: Float = (outSize / lineBreakInterval) - 1F
+
+                if (lineBreakCount > 0F) {
+                    if (lineBreakCount.rem(1) > 0F) {
+                        lineBreakCount++
+                    }
+
+                    if (outSize > (Long.MAX_VALUE - lineBreakCount)) {
+                        throw outSizeExceedsMaxEncodingSizeException(unEncodedSize, Long.MAX_VALUE)
+                    }
+
+                    outSize += lineBreakCount.toLong()
+                }
+            }
+
             return outSize
         }
 

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
@@ -151,4 +151,46 @@ class EncoderDecoderConfigUnitTest {
         assertEquals(0, config.lineBreakInterval)
     }
 
+    @Test
+    fun givenConfig_whenLineBreakIntervalExpressed_thenIncreasesEncodeOutSize() {
+        val config = TestConfig(isLenient = true, lineBreakInterval = 10, encodeReturn = { it })
+        listOf(
+            Pair(5L, 5L),
+            Pair(10L, 10L),
+            Pair(21L, 20L),
+            Pair(32L, 30L),
+            Pair(43L, 40L),
+        ).forEach { (expected, actual) ->
+            assertEquals(expected, config.encodeOutSize(actual))
+        }
+    }
+
+    @Test
+    fun givenLineBreakInterval_whenSizeIncreaseWouldExceedMaxValue_thenThrowsEncodingSizeException() {
+        val config = TestConfig(isLenient = true, lineBreakInterval = 10, encodeReturn = { it })
+
+        try {
+            config.encodeOutSize(Long.MAX_VALUE - 10L)
+            fail()
+        } catch (_: EncodingSizeException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun givenConfig_whenLineBreakIntervalZero_thenDoesNotAffectEncodeOutSize() {
+        val config = TestConfig(encodeReturn = { it })
+        assertEquals(0, config.lineBreakInterval)
+
+        listOf(
+            5L,
+            10L,
+            20L,
+            30L,
+            40L,
+        ).forEach { size ->
+            assertEquals(size, config.encodeOutSize(size))
+        }
+    }
+
 }

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderConfigUnitTest.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.encoding.core
 import io.matthewnelson.encoding.core.helpers.TestConfig
 import io.matthewnelson.encoding.core.util.DecoderInput
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.fail
 
 class EncoderDecoderConfigUnitTest {
@@ -119,4 +120,35 @@ class EncoderDecoderConfigUnitTest {
         config.decodeOutMaxSize(1L)
         config.encodeOutSize(1L)
     }
+
+    @Test
+    fun givenLineBreakInterval_whenIsLenientFalse_thenIsZero() {
+        val config = TestConfig(isLenient = false, lineBreakInterval = 20)
+
+        assertEquals(0, config.lineBreakInterval)
+    }
+
+    @Test
+    fun givenLineBreakInterval_whenIsLenientTrue_thenIsExpected() {
+        val expected: Byte = 20
+        val config = TestConfig(isLenient = true, lineBreakInterval = expected)
+
+        assertEquals(expected, config.lineBreakInterval)
+    }
+
+    @Test
+    fun givenLineBreakInterval_whenIsLenientNull_thenIsExpected() {
+        val expected: Byte = 20
+        val config = TestConfig(isLenient = null, lineBreakInterval = expected)
+
+        assertEquals(expected, config.lineBreakInterval)
+    }
+
+    @Test
+    fun givenConfig_whenLineBreakIntervalNegative_thenIsZero() {
+        val config = TestConfig(isLenient = true, lineBreakInterval = -5)
+
+        assertEquals(0, config.lineBreakInterval)
+    }
+
 }

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
@@ -194,4 +194,38 @@ class EncoderDecoderFeedUnitTest {
             assertTrue(feed.isClosed())
         }
     }
+
+    @Test
+    fun givenEncoderFeed_whenLineBreakExpressedInConfig_then() {
+        val encoder = TestEncoderDecoder(
+            config = TestConfig(
+                isLenient = true,
+                lineBreakInterval = 2,
+                encodeReturn = { it }
+            )
+        )
+        
+        var count = 0
+        val feed = encoder.newEncoderFeed { char ->
+            count++
+        }
+        
+        feed.consume(0)
+        feed.consume(0)
+        assertEquals(2, count)
+        feed.consume(0)
+        assertEquals(4, count)
+        feed.consume(0)
+        assertEquals(5, count)
+        feed.consume(0)
+        assertEquals(7, count)
+        feed.consume(0)
+        assertEquals(8, count)
+        feed.consume(0)
+        assertEquals(10, count)
+        feed.consume(0)
+        assertEquals(11, count)
+
+        feed.doFinal()
+    }
 }

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/EncoderDecoderFeedUnitTest.kt
@@ -206,7 +206,7 @@ class EncoderDecoderFeedUnitTest {
         )
         
         var count = 0
-        val feed = encoder.newEncoderFeed { char ->
+        val feed = encoder.newEncoderFeed { _ ->
             count++
         }
         

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestConfig.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestConfig.kt
@@ -22,11 +22,12 @@ import io.matthewnelson.encoding.core.util.DecoderInput
 @OptIn(ExperimentalEncodingApi::class)
 class TestConfig(
     isLenient: Boolean? = false,
+    lineBreakInterval: Byte = 0,
     paddingChar: Char? = '=',
     private val encodeReturn: (unEncodedSize: Long) -> Long = { -1L },
     private val decodeInputReturn: (encodedSize: Int) -> Int = { -1 },
     private val decodeReturn: (encodedSize: Long) -> Long = { -1L },
-): EncoderDecoder.Config(isLenient, paddingChar) {
+): EncoderDecoder.Config(isLenient, lineBreakInterval, paddingChar) {
     override fun decodeOutMaxSizeProtected(encodedSize: Long): Long {
         return decodeReturn.invoke(encodedSize)
     }

--- a/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestEncoderDecoder.kt
+++ b/library/encoding-core/src/commonTest/kotlin/io/matthewnelson/encoding/core/helpers/TestEncoderDecoder.kt
@@ -22,7 +22,7 @@ class TestEncoderDecoder(config: TestConfig): EncoderDecoder<TestConfig>(config)
     override fun name(): String = "Test"
 
     @ExperimentalEncodingApi
-    override fun newEncoderFeed(out: Encoder.OutFeed): Encoder<TestConfig>.Feed {
+    protected override fun newEncoderFeedProtected(out: Encoder.OutFeed): Encoder<TestConfig>.Feed {
         return object : Encoder<TestConfig>.Feed() {
             override fun consumeProtected(input: Byte) { out.output(Char.MAX_VALUE) }
             override fun doFinalProtected() { out.output(Char.MIN_VALUE) }


### PR DESCRIPTION
Closes #78 

Adds to the `EncoderDecoder.Config` the ability to pass a `lineBreakInterval` argument, which will insert new lines at the expressed interval for encoded output.